### PR TITLE
Multiple connections & connection opening/closing

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Those are the features/tasks that will probably come next (in no particular orde
 ```rust
 fn start_connection(client: ResMut<Client>) {
     client
-        .connect(
+        .open_connection(
             ClientConfigurationData::new(
                 "127.0.0.1".to_string(),
                 6000,
@@ -107,8 +107,7 @@ fn start_connection(client: ResMut<Client>) {
                 0,
             ),
             CertificateVerificationMode::SkipVerification,
-        )
-        .unwrap();
+        );
     
     // When trully connected, you will receive a ConnectionEvent
 ```
@@ -120,7 +119,7 @@ fn handle_server_messages(
     mut client: ResMut<Client>,
     /*...*/
 ) {
-    while let Ok(Some(message)) = client.receive_message::<ServerMessage>() {
+    while let Ok(Some(message)) = client.connection().receive_message::<ServerMessage>() {
         match message {
             // Match on your own message types ...
             ServerMessage::ClientConnected { client_id, username} => {/*...*/}
@@ -209,11 +208,11 @@ On the client:
 
 ```rust
     // To accept any certificate
-    client.connect(/*...*/, CertificateVerificationMode::SkipVerification);
+    client.open_connection(/*...*/, CertificateVerificationMode::SkipVerification);
     // To only accept certificates issued by a Certificate Authority
-    client.connect(/*...*/, CertificateVerificationMode::SignedByCertificateAuthority);
+    client.open_connection(/*...*/, CertificateVerificationMode::SignedByCertificateAuthority);
     // To use the default configuration of the Trust on first use authentication scheme
-    client.connect(/*...*/, CertificateVerificationMode::TrustOnFirstUse(TrustOnFirstUseConfig {
+    client.open_connection(/*...*/, CertificateVerificationMode::TrustOnFirstUse(TrustOnFirstUseConfig {
             // You can configure TrustOnFirstUse through the TrustOnFirstUseConfig:
             // Provide your own fingerprint store variable/file,
             // or configure the actions to apply for each possible certificate verification status.

--- a/docs/Certificates.md
+++ b/docs/Certificates.md
@@ -6,7 +6,7 @@
 
 Use the default configuration like this:
 ```rust
-client.connect(/*...*/, CertificateVerificationMode::TrustOnFirstUse(TrustOnFirstUseConfig {
+client.open_connection(/*...*/, CertificateVerificationMode::TrustOnFirstUse(TrustOnFirstUseConfig {
         ..Default::default()
     }),
 );
@@ -23,7 +23,7 @@ The defaults verifier behaviours are:
 
 Default verifier behaviours with a custom store file:
 ```rust
-client.connect(/*...*/, CertificateVerificationMode::TrustOnFirstUse(TrustOnFirstUseConfig {
+client.open_connection(/*...*/, CertificateVerificationMode::TrustOnFirstUse(TrustOnFirstUseConfig {
         known_hosts: KnownHosts::HostsFile("MyCustomFile".to_string()),
         ..Default::default()
     }),
@@ -32,7 +32,7 @@ client.connect(/*...*/, CertificateVerificationMode::TrustOnFirstUse(TrustOnFirs
 
 Custom verifier behaviours with a custom store:
 ```rust
-client.connect(/*...*/, CertificateVerificationMode::TrustOnFirstUse(TrustOnFirstUseConfig {
+client.open_connection(/*...*/, CertificateVerificationMode::TrustOnFirstUse(TrustOnFirstUseConfig {
         known_hosts: KnownHosts::Store(my_cert_store),
         verifier_behaviour: HashMap::from([
                 (

--- a/examples/breakout/client.rs
+++ b/examples/breakout/client.rs
@@ -200,7 +200,7 @@ pub(crate) fn handle_server_messages(
     mut scoreboard: ResMut<Scoreboard>,
     mut collision_events: EventWriter<CollisionEvent>,
 ) {
-    let mut connection = connection.get_single_mut().unwrap();
+    let mut connection = connection.single_mut();
     while let Ok(Some(message)) = connection.receive_message::<ServerMessage>() {
         match message {
             ServerMessage::InitClient { client_id } => {
@@ -302,7 +302,7 @@ pub(crate) fn move_paddle(
     }
 
     if local.current_input != paddle_input {
-        let connection = connection.get_single_mut().unwrap();
+        let connection = connection.single_mut();
         connection
             .send_message(ClientMessage::PaddleInput {
                 input: paddle_input.clone(),

--- a/examples/chat/client.rs
+++ b/examples/chat/client.rs
@@ -8,14 +8,14 @@ use bevy::{
     app::{AppExit, ScheduleRunnerPlugin},
     log::LogPlugin,
     prelude::{
-        info, warn, App, Commands, CoreStage, Deref, DerefMut, EventReader, EventWriter, Res,
+        info, warn, App, Commands, CoreStage, Deref, DerefMut, EventReader, EventWriter, Query,
         ResMut, Resource,
     },
 };
 use bevy_quinnet::{
     client::{
-        certificate::CertificateVerificationMode, Client, ClientConfigurationData, ConnectionEvent,
-        QuinnetClientPlugin,
+        certificate::{CertificateVerificationMode, TrustOnFirstUseConfig},
+        Client, Connection, ConnectionConfiguration, ConnectionEvent, QuinnetClientPlugin,
     },
     ClientId,
 };
@@ -35,16 +35,20 @@ struct Users {
 #[derive(Resource, Deref, DerefMut)]
 struct TerminalReceiver(mpsc::Receiver<String>);
 
-pub fn on_app_exit(app_exit_events: EventReader<AppExit>, client: Res<Client>) {
+pub fn on_app_exit(app_exit_events: EventReader<AppExit>, mut connection: Query<&Connection>) {
     if !app_exit_events.is_empty() {
-        client.send_message(ClientMessage::Disconnect {}).unwrap();
+        let connection = connection.get_single_mut().unwrap();
+        connection
+            .send_message(ClientMessage::Disconnect {})
+            .unwrap();
         // TODO Clean: event to let the async client send his last messages.
         sleep(Duration::from_secs_f32(0.1));
     }
 }
 
-fn handle_server_messages(mut client: ResMut<Client>, mut users: ResMut<Users>) {
-    while let Ok(Some(message)) = client.receive_message::<ServerMessage>() {
+fn handle_server_messages(mut users: ResMut<Users>, mut connection: Query<&mut Connection>) {
+    let mut connection = connection.get_single_mut().unwrap();
+    while let Ok(Some(message)) = connection.receive_message::<ServerMessage>() {
         match message {
             ServerMessage::ClientConnected {
                 client_id,
@@ -81,15 +85,16 @@ fn handle_server_messages(mut client: ResMut<Client>, mut users: ResMut<Users>) 
 }
 
 fn handle_terminal_messages(
-    client: ResMut<Client>,
     mut terminal_messages: ResMut<TerminalReceiver>,
     mut app_exit_events: EventWriter<AppExit>,
+    mut connection: Query<&Connection>,
 ) {
+    let connection = connection.get_single_mut().unwrap();
     while let Ok(message) = terminal_messages.try_recv() {
         if message == "quit" {
             app_exit_events.send(AppExit);
         } else {
-            client
+            connection
                 .send_message(ClientMessage::ChatMessage { message: message })
                 .expect("Failed to send chat message");
         }
@@ -110,18 +115,25 @@ fn start_terminal_listener(mut commands: Commands) {
     commands.insert_resource(TerminalReceiver(from_terminal_receiver));
 }
 
-fn start_connection(client: ResMut<Client>) {
-    client
-        .connect(
-            ClientConfigurationData::new("127.0.0.1".to_string(), 6000, "0.0.0.0".to_string(), 0),
-            CertificateVerificationMode::SkipVerification,
-        )
-        .unwrap();
+fn start_connection(mut commands: Commands, client: ResMut<Client>) {
+    client.spawn_connection(
+        &mut commands,
+        ConnectionConfiguration::new("127.0.0.1".to_string(), 6000, "0.0.0.0".to_string(), 0),
+        CertificateVerificationMode::TrustOnFirstUse(TrustOnFirstUseConfig {
+            known_hosts: bevy_quinnet::client::certificate::KnownHosts::HostsFile(
+                "my_own_hosts_file".to_string(),
+            ),
+            ..Default::default()
+        }),
+    );
 
-    // You can already send message(s) even before being connected, they will be buffered. In this example we will wait for a ConnectionEvent. We could also check client.is_connected()
+    // You can already send message(s) even before being connected, they will be buffered. In this example we will wait for a ConnectionEvent.
 }
 
-fn handle_client_events(connection_events: EventReader<ConnectionEvent>, client: ResMut<Client>) {
+fn handle_client_events(
+    connection_events: EventReader<ConnectionEvent>,
+    mut connection: Query<&Connection>,
+) {
     if !connection_events.is_empty() {
         // We are connected
         let username: String = rand::thread_rng()
@@ -133,7 +145,8 @@ fn handle_client_events(connection_events: EventReader<ConnectionEvent>, client:
         println!("--- Joining with name: {}", username);
         println!("--- Type 'quit' to disconnect");
 
-        client
+        let connection = connection.get_single_mut().unwrap();
+        connection
             .send_message(ClientMessage::Join { name: username })
             .unwrap();
 

--- a/examples/chat/server.rs
+++ b/examples/chat/server.rs
@@ -114,7 +114,11 @@ fn start_listening(mut server: ResMut<Server>) {
     server
         .start(
             ServerConfigurationData::new("127.0.0.1".to_string(), 6000, "0.0.0.0".to_string()),
-            CertificateRetrievalMode::GenerateSelfSigned,
+            CertificateRetrievalMode::LoadFromFileOrGenerateSelfSigned {
+                cert_file: "cert.pem".to_string(),
+                key_file: "key.pem".to_string(),
+                save_on_disk: true,
+            },
         )
         .unwrap();
 }

--- a/examples/chat/server.rs
+++ b/examples/chat/server.rs
@@ -114,11 +114,7 @@ fn start_listening(mut server: ResMut<Server>) {
     server
         .start(
             ServerConfigurationData::new("127.0.0.1".to_string(), 6000, "0.0.0.0".to_string()),
-            CertificateRetrievalMode::LoadFromFileOrGenerateSelfSigned {
-                cert_file: "cert.pem".to_string(),
-                key_file: "key.pem".to_string(),
-                save_on_disk: true,
-            },
+            CertificateRetrievalMode::GenerateSelfSigned,
         )
         .unwrap();
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -11,6 +11,7 @@ use futures_util::StreamExt;
 use quinn::{ClientConfig, Endpoint};
 use serde::Deserialize;
 use tokio::{
+    runtime::{self},
     sync::{
         broadcast,
         mpsc::{
@@ -38,21 +39,23 @@ pub mod certificate;
 pub const DEFAULT_INTERNAL_MESSAGE_CHANNEL_SIZE: usize = 100;
 pub const DEFAULT_KNOWN_HOSTS_FILE: &str = "quinnet/known_hosts";
 
+pub type ConnectionId = Entity;
+
 /// Connection event raised when the client just connected to the server. Raised in the CoreStage::PreUpdate stage.
-pub struct ConnectionEvent;
+pub struct ConnectionEvent(ConnectionId);
 /// ConnectionLost event raised when the client is considered disconnected from the server. Raised in the CoreStage::PreUpdate stage.
-pub struct ConnectionLostEvent;
+pub struct ConnectionLostEvent(ConnectionId);
 
 /// Configuration of the client, used when connecting to a server
 #[derive(Debug, Deserialize, Clone)]
-pub struct ClientConfigurationData {
+pub struct ConnectionConfiguration {
     server_host: String,
     server_port: u16,
     local_bind_host: String,
     local_bind_port: u16,
 }
 
-impl ClientConfigurationData {
+impl ConnectionConfiguration {
     /// Creates a new ClientConfigurationData
     ///
     /// # Arguments
@@ -89,7 +92,7 @@ impl ClientConfigurationData {
 
 /// Current state of the client driver
 #[derive(Debug, PartialEq, Eq)]
-enum ClientState {
+enum ConnectionState {
     Disconnected,
     Connected,
 }
@@ -110,42 +113,29 @@ pub(crate) enum InternalAsyncMessage {
     },
 }
 
-#[derive(Debug, Clone)]
-pub(crate) enum InternalSyncMessage {
-    Connect {
-        config: ClientConfigurationData,
-        cert_mode: CertificateVerificationMode,
-    },
+#[derive(Debug)]
+pub(crate) struct ConnectionSpawnConfig {
+    connection_config: ConnectionConfiguration,
+    cert_mode: CertificateVerificationMode,
+    to_sync_client: mpsc::Sender<InternalAsyncMessage>,
+    close_sender: tokio::sync::broadcast::Sender<()>,
+    close_receiver: tokio::sync::broadcast::Receiver<()>,
+    to_server_receiver: mpsc::Receiver<Bytes>,
+    from_server_sender: mpsc::Sender<Bytes>,
 }
 
-#[derive(Resource)]
-pub struct Client {
-    state: ClientState,
+#[derive(Component)]
+pub struct Connection {
+    state: ConnectionState,
     // TODO Perf: multiple channels
     sender: mpsc::Sender<Bytes>,
     receiver: mpsc::Receiver<Bytes>,
     close_sender: broadcast::Sender<()>,
-
     pub(crate) internal_receiver: mpsc::Receiver<InternalAsyncMessage>,
-    pub(crate) internal_sender: mpsc::Sender<InternalSyncMessage>,
+    // pub(crate) internal_sender: mpsc::Sender<InternalSyncMessage>,
 }
 
-impl Client {
-    /// Connect to a server with the given [ClientConfigurationData] and [CertificateVerificationMode]
-    pub fn connect(
-        &self,
-        config: ClientConfigurationData,
-        cert_mode: CertificateVerificationMode,
-    ) -> Result<(), QuinnetError> {
-        match self
-            .internal_sender
-            .try_send(InternalSyncMessage::Connect { config, cert_mode })
-        {
-            Ok(_) => Ok(()),
-            Err(_) => Err(QuinnetError::FullQueue),
-        }
-    }
-
+impl Connection {
     /// Disconnect the client. This does not send any message to the server, and simply closes all the connection tasks locally.
     pub fn disconnect(&mut self) -> Result<(), QuinnetError> {
         if self.is_connected() {
@@ -153,7 +143,7 @@ impl Client {
                 return Err(QuinnetError::ChannelClosed);
             }
         }
-        self.state = ClientState::Disconnected;
+        self.state = ConnectionState::Disconnected;
         Ok(())
     }
 
@@ -197,7 +187,63 @@ impl Client {
     }
 
     pub fn is_connected(&self) -> bool {
-        return self.state == ClientState::Connected;
+        return self.state == ConnectionState::Connected;
+    }
+}
+
+#[derive(Resource)]
+pub struct Client {
+    // connections: HashMap<ConnectionId, Connection>,
+    runtime: runtime::Handle,
+}
+
+impl Client {
+    /// Connect to a server with the given [ClientConfigurationData] and [CertificateVerificationMode]
+    pub fn spawn_connection(
+        &self,
+        commands: &mut Commands,
+        config: ConnectionConfiguration,
+        cert_mode: CertificateVerificationMode,
+    ) -> ConnectionId {
+        let (from_server_sender, from_server_receiver) =
+            mpsc::channel::<Bytes>(DEFAULT_MESSAGE_QUEUE_SIZE);
+        let (to_server_sender, to_server_receiver) =
+            mpsc::channel::<Bytes>(DEFAULT_MESSAGE_QUEUE_SIZE);
+
+        let (to_sync_client, from_async_client) =
+            mpsc::channel::<InternalAsyncMessage>(DEFAULT_INTERNAL_MESSAGE_CHANNEL_SIZE);
+
+        // Create a close channel for this connection
+        let (close_sender, close_receiver): (
+            tokio::sync::broadcast::Sender<()>,
+            tokio::sync::broadcast::Receiver<()>,
+        ) = broadcast::channel(DEFAULT_KILL_MESSAGE_QUEUE_SIZE);
+
+        let connection = commands
+            .spawn(Connection {
+                state: ConnectionState::Disconnected,
+                sender: to_server_sender,
+                receiver: from_server_receiver,
+                close_sender: close_sender.clone(),
+                internal_receiver: from_async_client,
+                // internal_sender: to_async_client,
+            })
+            .id();
+
+        // Async connection
+        self.runtime.spawn(async move {
+            connection_task(ConnectionSpawnConfig {
+                connection_config: config,
+                cert_mode,
+                to_sync_client,
+                close_sender,
+                close_receiver,
+                to_server_receiver,
+                from_server_sender,
+            })
+            .await
+        });
+        connection
     }
 }
 
@@ -233,15 +279,8 @@ fn configure_client(
     }
 }
 
-async fn connection_task(
-    config: ClientConfigurationData,
-    cert_mode: CertificateVerificationMode,
-    to_sync_client: mpsc::Sender<InternalAsyncMessage>,
-    close_sender: tokio::sync::broadcast::Sender<()>,
-    mut close_receiver: tokio::sync::broadcast::Receiver<()>,
-    mut to_server_receiver: mpsc::Receiver<Bytes>,
-    from_server_sender: mpsc::Sender<Bytes>,
-) {
+async fn connection_task(mut spawn_config: ConnectionSpawnConfig) {
+    let config = spawn_config.connection_config;
     let server_adr_str = format!("{}:{}", config.server_host, config.server_port);
     let srv_host = config.server_host.clone();
     let local_bind_adr = format!("{}:{}", config.local_bind_host, config.local_bind_port);
@@ -252,8 +291,8 @@ async fn connection_task(
         .parse()
         .expect("Failed to parse server address");
 
-    let client_cfg =
-        configure_client(cert_mode, to_sync_client.clone()).expect("Failed to configure client");
+    let client_cfg = configure_client(spawn_config.cert_mode, spawn_config.to_sync_client.clone())
+        .expect("Failed to configure client");
 
     let mut endpoint = Endpoint::client(local_bind_adr.parse().unwrap())
         .expect("Failed to create client endpoint");
@@ -271,7 +310,8 @@ async fn connection_task(
                 new_connection.connection.remote_address()
             );
 
-            to_sync_client
+            spawn_config
+                .to_sync_client
                 .send(InternalAsyncMessage::Connected)
                 .await
                 .expect("Failed to signal connection to sync client");
@@ -283,21 +323,21 @@ async fn connection_task(
                 .expect("Failed to open send stream");
             let mut frame_send = FramedWrite::new(send, LengthDelimitedCodec::new());
 
-            let close_sender_clone = close_sender.clone();
+            let close_sender_clone = spawn_config.close_sender.clone();
             let _network_sends = tokio::spawn(async move {
                 tokio::select! {
-                    _ = close_receiver.recv() => {
+                    _ = spawn_config.close_receiver.recv() => {
                         trace!("Unidirectional send Stream forced to disconnected")
                     }
                     _ = async {
-                        while let Some(msg_bytes) = to_server_receiver.recv().await {
+                        while let Some(msg_bytes) = spawn_config.to_server_receiver.recv().await {
                             if let Err(err) = frame_send.send(msg_bytes).await {
                                 error!("Error while sending, {}", err); // TODO Clean: error handling
                                 error!("Client seems disconnected, closing resources");
                                 if let Err(_) = close_sender_clone.send(()) {
                                     error!("Failed to close all client streams & resources")
                                 }
-                                to_sync_client.send(
+                                spawn_config.to_sync_client.send(
                                     InternalAsyncMessage::LostConnection)
                                     .await
                                     .expect("Failed to signal connection lost to sync client");
@@ -310,7 +350,7 @@ async fn connection_task(
             });
 
             let mut uni_receivers: JoinSet<()> = JoinSet::new();
-            let mut close_receiver = close_sender.subscribe();
+            let mut close_receiver = spawn_config.close_sender.subscribe();
             let _network_reads = tokio::spawn(async move {
                 tokio::select! {
                     _ = close_receiver.recv() => {
@@ -319,7 +359,7 @@ async fn connection_task(
                     _ = async {
                         while let Some(Ok(recv)) = new_connection.uni_streams.next().await {
                             let mut frame_recv = FramedRead::new(recv, LengthDelimitedCodec::new());
-                            let from_server_sender = from_server_sender.clone();
+                            let from_server_sender = spawn_config.from_server_sender.clone();
 
                             uni_receivers.spawn(async move {
                                 while let Some(Ok(msg_bytes)) = frame_recv.next().await {
@@ -338,88 +378,57 @@ async fn connection_task(
     }
 }
 
-fn start_async_client(mut commands: Commands, runtime: Res<AsyncRuntime>) {
-    let (from_server_sender, from_server_receiver) =
-        mpsc::channel::<Bytes>(DEFAULT_MESSAGE_QUEUE_SIZE);
-    let (to_server_sender, to_server_receiver) = mpsc::channel::<Bytes>(DEFAULT_MESSAGE_QUEUE_SIZE);
-
-    let (to_sync_client, from_async_client) =
-        mpsc::channel::<InternalAsyncMessage>(DEFAULT_INTERNAL_MESSAGE_CHANNEL_SIZE);
-    let (to_async_client, mut from_sync_client) =
-        mpsc::channel::<InternalSyncMessage>(DEFAULT_INTERNAL_MESSAGE_CHANNEL_SIZE);
-
-    // Create a close channel for this connection
-    let (close_sender, close_receiver): (
-        tokio::sync::broadcast::Sender<()>,
-        tokio::sync::broadcast::Receiver<()>,
-    ) = broadcast::channel(DEFAULT_KILL_MESSAGE_QUEUE_SIZE);
-
+fn create_client(mut commands: Commands, runtime: Res<AsyncRuntime>) {
     commands.insert_resource(Client {
-        state: ClientState::Disconnected,
-        sender: to_server_sender,
-        receiver: from_server_receiver,
-        close_sender: close_sender.clone(),
-        internal_receiver: from_async_client,
-        internal_sender: to_async_client.clone(),
-    });
-
-    // Async client
-    runtime.spawn(async move {
-        // Wait for a connection signal before starting client
-        if let Some(message) = from_sync_client.recv().await {
-            match message {
-                InternalSyncMessage::Connect { config, cert_mode } => {
-                    connection_task(
-                        config,
-                        cert_mode,
-                        to_sync_client,
-                        close_sender,
-                        close_receiver,
-                        to_server_receiver,
-                        from_server_sender,
-                    )
-                    .await;
-                }
-            }
-        }
+        runtime: runtime.handle().clone(),
     });
 }
 
 // Receive messages from the async client tasks and update the sync client.
 fn update_sync_client(
-    mut client: ResMut<Client>,
     mut connection_events: EventWriter<ConnectionEvent>,
     mut connection_lost_events: EventWriter<ConnectionLostEvent>,
     mut certificate_interaction_events: EventWriter<CertInteractionEvent>,
     mut cert_trust_update_events: EventWriter<CertTrustUpdateEvent>,
     mut cert_connection_abort_events: EventWriter<CertConnectionAbortEvent>,
+    mut connections: Query<(&mut Connection, ConnectionId)>,
 ) {
-    while let Ok(message) = client.internal_receiver.try_recv() {
-        match message {
-            InternalAsyncMessage::Connected => {
-                client.state = ClientState::Connected;
-                connection_events.send(ConnectionEvent);
-            }
-            InternalAsyncMessage::LostConnection => {
-                client.state = ClientState::Disconnected;
-                connection_lost_events.send(ConnectionLostEvent);
-            }
-            InternalAsyncMessage::CertificateInteractionRequest {
-                status,
-                info,
-                action_sender,
-            } => {
-                certificate_interaction_events.send(CertInteractionEvent {
+    for (mut connection, connection_id) in connections.iter_mut() {
+        while let Ok(message) = connection.internal_receiver.try_recv() {
+            match message {
+                InternalAsyncMessage::Connected => {
+                    connection.state = ConnectionState::Connected;
+                    connection_events.send(ConnectionEvent(connection_id));
+                }
+                InternalAsyncMessage::LostConnection => {
+                    connection.state = ConnectionState::Disconnected;
+                    connection_lost_events.send(ConnectionLostEvent(connection_id));
+                }
+                InternalAsyncMessage::CertificateInteractionRequest {
                     status,
                     info,
-                    action_sender: Mutex::new(Some(action_sender)),
-                });
-            }
-            InternalAsyncMessage::CertificateTrustUpdate(info) => {
-                cert_trust_update_events.send(CertTrustUpdateEvent(info));
-            }
-            InternalAsyncMessage::CertificateConnectionAbort { status, cert_info } => {
-                cert_connection_abort_events.send(CertConnectionAbortEvent { status, cert_info });
+                    action_sender,
+                } => {
+                    certificate_interaction_events.send(CertInteractionEvent {
+                        connection_id,
+                        status,
+                        info,
+                        action_sender: Mutex::new(Some(action_sender)),
+                    });
+                }
+                InternalAsyncMessage::CertificateTrustUpdate(info) => {
+                    cert_trust_update_events.send(CertTrustUpdateEvent {
+                        connection_id,
+                        cert_info: info,
+                    });
+                }
+                InternalAsyncMessage::CertificateConnectionAbort { status, cert_info } => {
+                    cert_connection_abort_events.send(CertConnectionAbortEvent {
+                        connection_id,
+                        status,
+                        cert_info,
+                    });
+                }
             }
         }
     }
@@ -441,7 +450,7 @@ impl Plugin for QuinnetClientPlugin {
             .add_event::<CertTrustUpdateEvent>()
             .add_event::<CertConnectionAbortEvent>()
             // StartupStage::PreStartup so that resources created in commands are available to default startup_systems
-            .add_startup_system_to_stage(StartupStage::PreStartup, start_async_client)
+            .add_startup_system_to_stage(StartupStage::PreStartup, create_client)
             .add_system(update_sync_client);
 
         if app.world.get_resource_mut::<AsyncRuntime>().is_none() {

--- a/src/client.rs
+++ b/src/client.rs
@@ -132,11 +132,10 @@ pub struct Connection {
     receiver: mpsc::Receiver<Bytes>,
     close_sender: broadcast::Sender<()>,
     pub(crate) internal_receiver: mpsc::Receiver<InternalAsyncMessage>,
-    // pub(crate) internal_sender: mpsc::Sender<InternalSyncMessage>,
 }
 
 impl Connection {
-    /// Disconnect the client. This does not send any message to the server, and simply closes all the connection tasks locally.
+    /// Closes this connection. This does not send any message to the server, and simply closes all the connection's tasks locally.
     pub fn disconnect(&mut self) -> Result<(), QuinnetError> {
         if self.is_connected() {
             if let Err(_) = self.close_sender.send(()) {
@@ -193,12 +192,11 @@ impl Connection {
 
 #[derive(Resource)]
 pub struct Client {
-    // connections: HashMap<ConnectionId, Connection>,
     runtime: runtime::Handle,
 }
 
 impl Client {
-    /// Connect to a server with the given [ClientConfigurationData] and [CertificateVerificationMode]
+    /// Sapwn a connection to a server with the given [ConnectionConfiguration] and [CertificateVerificationMode]
     pub fn spawn_connection(
         &self,
         commands: &mut Commands,
@@ -226,7 +224,6 @@ impl Client {
                 receiver: from_server_receiver,
                 close_sender: close_sender.clone(),
                 internal_receiver: from_async_client,
-                // internal_sender: to_async_client,
             })
             .id();
 
@@ -378,12 +375,6 @@ async fn connection_task(mut spawn_config: ConnectionSpawnConfig) {
     }
 }
 
-fn create_client(mut commands: Commands, runtime: Res<AsyncRuntime>) {
-    commands.insert_resource(Client {
-        runtime: runtime.handle().clone(),
-    });
-}
-
 // Receive messages from the async client tasks and update the sync client.
 fn update_sync_client(
     mut connection_events: EventWriter<ConnectionEvent>,
@@ -432,6 +423,12 @@ fn update_sync_client(
             }
         }
     }
+}
+
+fn create_client(mut commands: Commands, runtime: Res<AsyncRuntime>) {
+    commands.insert_resource(Client {
+        runtime: runtime.handle().clone(),
+    });
 }
 
 pub struct QuinnetClientPlugin {}

--- a/src/client/certificate.rs
+++ b/src/client/certificate.rs
@@ -15,13 +15,14 @@ use tokio::sync::{mpsc, oneshot};
 
 use crate::QuinnetError;
 
-use super::{InternalAsyncMessage, DEFAULT_KNOWN_HOSTS_FILE};
+use super::{ConnectionId, InternalAsyncMessage, DEFAULT_KNOWN_HOSTS_FILE};
 
 pub const DEFAULT_CERT_VERIFIER_BEHAVIOUR: CertVerifierBehaviour =
     CertVerifierBehaviour::ImmediateAction(CertVerifierAction::AbortConnection);
 
 /// Event raised when a user/app interaction is needed for the server's certificate validation
 pub struct CertInteractionEvent {
+    pub connection_id: ConnectionId,
     /// The current status of the verification
     pub status: CertVerificationStatus,
     /// Server & Certificate info
@@ -48,10 +49,14 @@ impl CertInteractionEvent {
 }
 
 /// Event raised when a new certificate is trusted
-pub struct CertTrustUpdateEvent(pub CertVerificationInfo);
+pub struct CertTrustUpdateEvent {
+    pub connection_id: ConnectionId,
+    pub cert_info: CertVerificationInfo,
+}
 
 /// Event raised when a connection is aborted during the certificate verification
 pub struct CertConnectionAbortEvent {
+    pub connection_id: ConnectionId,
     pub status: CertVerificationStatus,
     pub cert_info: CertVerificationInfo,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 use std::sync::PoisonError;
 
 use bevy::prelude::{Deref, DerefMut, Resource};
+use client::ConnectionId;
 use tokio::runtime::Runtime;
 
 pub const DEFAULT_MESSAGE_QUEUE_SIZE: usize = 150;
@@ -20,6 +21,8 @@ pub(crate) struct AsyncRuntime(pub(crate) Runtime);
 pub enum QuinnetError {
     #[error("Client with id `{0}` is unknown")]
     UnknownClient(ClientId),
+    #[error("Connection with id `{0}` is unknown")]
+    UnknownConnection(ConnectionId),
     #[error("Failed serialization")]
     Serialization,
     #[error("Failed deserialization")]


### PR DESCRIPTION
- Adds support for the client plugin to handle multiple server connections simultaneously
- Also adds support for opening & closing a connection multiple times which was previously not possible

Connections are opened/closed from the Client resource.

Alternatives:

Another approach was attempted on the `connection-component` branch. in this other branch, each connection is a component on an entity spawned by the client.
Although it allows for some Bevy ECS style access to the connections, I found that it polluted the ECS World too much with objects that make more sense as global objects in a resource.