### PR TITLE
Expose a function for retrieving stats about a connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,6 +522,7 @@ dependencies = [
  "futures",
  "futures-util",
  "quinn",
+ "quinn-proto",
  "rand",
  "rcgen",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ tokio = { version = "1.21.2", features = ["sync", "rt-multi-thread", "macros"] }
 tokio-util = { version = "0.7.4", features = ["codec"] }
 rcgen = "0.10.0"
 quinn = "0.9.1"
+quinn-proto = "0.9.1"
 futures-util = "0.3.24"
 futures = "0.3.24"
 bincode = "1.3.3"


### PR DESCRIPTION
I wanted a way for exposing [ConnectionStats](https://github.com/quinn-rs/quinn/blob/2c6aa4361059dead63ab9299b4a78180247a4dc3/quinn/src/connection.rs#L459-L462) and came up with a quick POC of storing the internal Quinn connection when the successful connection is made. This lets you call `.stats()` on it later on, which is useful for grabbing the RTT / net stats for observability.

I'm not sure if this is the best way about going about it, so I'm up for amending this in whichever way you see fit! (I'm not sure if we want to just re-export the ConnectionStats struct from quinn-proto, it seems quinn itself doesn't re-export this for some reason.. )