### PR TITLE
Add send channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ There are currently 3 types of channels available when you send a message:
 - `UnorderedReliable`: ensure that messages sent are delivered, in any order (exemple usage: an animation trigger)
 - `Unreliable`: no guarantees on the delivery or the order of processing by the receiving end (exemple usage: an entity position sent every ticks)
 
-By default for the server as well as the client, Quinnet creates 1 channel instance of each type, eahc with their own ChannelId. Among those, there is a `default` channel which will be used when you don't specify the channel. At startup, this default channel is an `OrderedReliable` channel.
+By default for the server as well as the client, Quinnet creates 1 channel instance of each type, each with their own `ChannelId`. Among those, there is a `default` channel which will be used when you don't specify the channel. At startup, this default channel is an `OrderedReliable` channel.
 
 ```rust
 let connection = client.connection();
@@ -213,12 +213,12 @@ connection.send_message_on(ChannelId::UnorderedReliable, message);
 connection.set_default_channel(ChannelId::Unreliable);
 ```
 
-One channel instance is more than enough for `UnorderedReliable` and `Unreliable` since messages are not ordered on those, in fact even if you tried to create more, Quinnet would just reuse the existing ones. This is why you can directly use their ChannelId when sending messages as seen above.
+One channel instance is more than enough for `UnorderedReliable` and `Unreliable` since messages are not ordered on those, in fact even if you tried to create more, Quinnet would just reuse the existing ones. This is why you can directly use their `ChannelId` when sending messages, as seen above.
 
 In some cases, you may however want to create more than one channel instance, it may be the case for `OrderedReliable` channels to avoid some [Head of line blocking](https://en.wikipedia.org/wiki/Head-of-line_blocking) issues. Channels can be opened & closed at any time.
 
 ```rust
-// If you want to create more channels:
+// If you want to create more channels
 let chat_channel = client.connection().open_channel(ChannelType::OrderedReliable).unwrap();
 client.connection().send_message_on(chat_channel, chat_message);
 ```

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ Those are the features/tasks that will probably come next (in no particular orde
 - [x] Feature: Send messages from the server to a specific client
 - [x] Feature: Send messages from the server to a selected group of clients
 - [x] Feature: Raise connection/disconnection events from the plugins
-- [ ] Feature: Send unordered reliable messages from the server
+- [ ] Feature: Expose unordered & ordered reliable message channels from client & server
+- [ ] Feature: Send & receive unreliable messages from client & server
 - [x] Feature: Implementing a way to launch a local server from a client
 - [x] Feature: Client should be capable to connect to another server after disconnecting
 - [ ] Performance: Messages aggregation before sending

--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ Those are the features/tasks that will probably come next (in no particular orde
 - [x] Feature: Send messages from the server to a selected group of clients
 - [x] Feature: Raise connection/disconnection events from the plugins
 - [x] Feature: Implement unordered & ordered reliable message channels from client & server
-- [ ] Feature: Implement unreliable message channel from client & server
-- [ ] Feature: Send unreliable messages larger than the MTU from client & server
+- [x] Feature: Implement unreliable message channel from client & server
+- [ ] Feature: Send unreliable messages larger than the path MTU from client & server
 - [x] Feature: Implementing a way to launch a local server from a client
 - [x] Feature: Client should be capable to connect to another server after disconnecting
-- [ ] Performance: feed multiples messages before flushing channels
+- [ ] Performance: feed multiples messages before flushing ordered reliable channels
 - [ ] Clean: Rework the error handling in the async back-end
 - [x] Clean: Rework the configuration input for the client & server plugins
 - [ ] Documentation: Fully document the API

--- a/examples/breakout/client.rs
+++ b/examples/breakout/client.rs
@@ -91,15 +91,17 @@ struct WallBundle {
 }
 
 pub(crate) fn start_connection(mut client: ResMut<Client>) {
-    client.open_connection(
-        ConnectionConfiguration::new(
-            SERVER_HOST.to_string(),
-            SERVER_PORT,
-            "0.0.0.0".to_string(),
-            0,
-        ),
-        CertificateVerificationMode::SkipVerification,
-    );
+    client
+        .open_connection(
+            ConnectionConfiguration::new(
+                SERVER_HOST.to_string(),
+                SERVER_PORT,
+                "0.0.0.0".to_string(),
+                0,
+            ),
+            CertificateVerificationMode::SkipVerification,
+        )
+        .unwrap();
 }
 
 fn spawn_paddle(commands: &mut Commands, position: &Vec3, owned: bool) -> Entity {

--- a/examples/chat/client.rs
+++ b/examples/chat/client.rs
@@ -117,10 +117,12 @@ fn start_terminal_listener(mut commands: Commands) {
 }
 
 fn start_connection(mut client: ResMut<Client>) {
-    client.open_connection(
-        ConnectionConfiguration::new("127.0.0.1".to_string(), 6000, "0.0.0.0".to_string(), 0),
-        CertificateVerificationMode::SkipVerification,
-    );
+    client
+        .open_connection(
+            ConnectionConfiguration::new("127.0.0.1".to_string(), 6000, "0.0.0.0".to_string(), 0),
+            CertificateVerificationMode::SkipVerification,
+        )
+        .unwrap();
 
     // You can already send message(s) even before being connected, they will be buffered. In this example we will wait for a ConnectionEvent.
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -314,6 +314,9 @@ impl Connection {
 
     /// Immediately prevents new messages from being sent on the channel and signal the channel to closes all its background tasks.
     /// Before trully closing, the channel will wait for all buffered messages to be properly sent according to the channel type.
+    ///
+    /// If called on the default channel, set default channel to None.
+    ///
     /// Can fail if the [ChannelId] is unknown, or if the channel is already closed.
     pub fn close_channel(&mut self, channel_id: ChannelId) -> Result<(), QuinnetError> {
         match self.channels.remove(&channel_id) {

--- a/src/client.rs
+++ b/src/client.rs
@@ -31,7 +31,7 @@ use tokio_util::codec::{FramedRead, LengthDelimitedCodec};
 use crate::shared::{
     channel::{
         ordered_reliable_channel_task, unordered_reliable_channel_task, Channel, ChannelId,
-        ChannelType, OrdRelChannelId,
+        ChannelType, MultiChannelId,
     },
     AsyncRuntime, QuinnetError, DEFAULT_KILL_MESSAGE_QUEUE_SIZE, DEFAULT_MESSAGE_QUEUE_SIZE,
 };
@@ -152,7 +152,7 @@ pub struct Connection {
     state: ConnectionState,
     channels: HashMap<ChannelId, Channel>,
     default_channel: Option<ChannelId>,
-    last_gen_id: OrdRelChannelId,
+    last_gen_id: MultiChannelId,
     receiver: mpsc::Receiver<Bytes>,
     close_sender: broadcast::Sender<()>,
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -430,11 +430,13 @@ impl Client {
     }
 
     /// Open a connection to a server with the given [ConnectionConfiguration] and [CertificateVerificationMode]. The connection will raise an event when fully connected, see [ConnectionEvent]
+    ///
+    /// Returns the [ConnectionId], and the default [ChannelId]
     pub fn open_connection(
         &mut self,
         config: ConnectionConfiguration,
         cert_mode: CertificateVerificationMode,
-    ) -> Result<ConnectionId, QuinnetError> {
+    ) -> Result<(ConnectionId, ChannelId), QuinnetError> {
         let (bytes_from_server_send, bytes_from_server_recv) =
             mpsc::channel::<Bytes>(DEFAULT_MESSAGE_QUEUE_SIZE);
 
@@ -460,7 +462,7 @@ impl Client {
             from_channels_recv,
         };
         // Create default channels
-        connection.open_channel(ChannelType::OrderedReliable)?;
+        let ordered_reliable_id = connection.open_channel(ChannelType::OrderedReliable)?;
         connection.open_channel(ChannelType::UnorderedReliable)?;
         connection.open_channel(ChannelType::Unreliable)?;
 
@@ -485,7 +487,7 @@ impl Client {
             self.default_connection_id = Some(connection_id);
         }
 
-        Ok(connection_id)
+        Ok((connection_id, ordered_reliable_id))
     }
 
     /// Set the default connection

--- a/src/client.rs
+++ b/src/client.rs
@@ -330,6 +330,16 @@ impl Connection {
         }
     }
 
+    /// Set the default channel
+    pub fn set_default_channel(&mut self, channel_id: ChannelId) {
+        self.default_channel = Some(channel_id);
+    }
+
+    /// Get the default Channel Id
+    pub fn get_default_channel(&self) -> Option<ChannelId> {
+        self.default_channel
+    }
+
     fn create_channel(&mut self, channel_id: ChannelId) -> Result<ChannelId, QuinnetError> {
         let (bytes_to_channel_send, bytes_to_channel_recv) =
             mpsc::channel::<Bytes>(DEFAULT_MESSAGE_QUEUE_SIZE);

--- a/src/client.rs
+++ b/src/client.rs
@@ -251,7 +251,7 @@ impl Connection {
                 Ok(msg_payload) => Ok(Some(msg_payload)),
                 Err(err) => match err {
                     TryRecvError::Empty => Ok(None),
-                    TryRecvError::Disconnected => Err(QuinnetError::ChannelClosed),
+                    TryRecvError::Disconnected => Err(QuinnetError::InternalChannelClosed),
                 },
             },
         }
@@ -276,7 +276,7 @@ impl Connection {
                 self.state = ConnectionState::Disconnected;
                 match self.close_sender.send(()) {
                     Ok(_) => Ok(()),
-                    Err(_) => Err(QuinnetError::ChannelClosed),
+                    Err(_) => Err(QuinnetError::InternalChannelClosed),
                 }
             }
         }
@@ -346,7 +346,7 @@ impl Connection {
             }
             Err(err) => match err {
                 TrySendError::Full(_) => Err(QuinnetError::FullQueue),
-                TrySendError::Closed(_) => Err(QuinnetError::ChannelClosed),
+                TrySendError::Closed(_) => Err(QuinnetError::InternalChannelClosed),
             },
         }
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -611,10 +611,13 @@ async fn connection_task(spawn_config: ConnectionSpawnConfig) {
                 tokio::spawn(async move {
                     let conn_err = conn.closed().await;
                     info!("Disconnected: {}", conn_err);
-                    to_sync_client
-                        .send(ClientAsyncMessage::ConnectionClosed(conn_err))
-                        .await
-                        .expect("Failed to signal connection lost to sync client");
+                    // If we requested the connection to close, channel may have been closed already.
+                    if !to_sync_client.is_closed() {
+                        to_sync_client
+                            .send(ClientAsyncMessage::ConnectionClosed(conn_err))
+                            .await
+                            .expect("Failed to signal connection lost to sync client");
+                    }
                 })
             };
 

--- a/src/client/certificate.rs
+++ b/src/client/certificate.rs
@@ -40,7 +40,7 @@ impl CertInteractionEvent {
         if let Some(sender) = sender.take() {
             match sender.send(action) {
                 Ok(_) => Ok(()),
-                Err(_) => Err(QuinnetError::ChannelClosed),
+                Err(_) => Err(QuinnetError::InternalChannelClosed),
             }
         } else {
             Err(QuinnetError::CertificateActionAlreadyApplied)

--- a/src/client/certificate.rs
+++ b/src/client/certificate.rs
@@ -15,7 +15,7 @@ use tokio::sync::{mpsc, oneshot};
 
 use crate::shared::{CertificateFingerprint, QuinnetError};
 
-use super::{ConnectionId, InternalAsyncMessage, DEFAULT_KNOWN_HOSTS_FILE};
+use super::{ClientAsyncMessage, ConnectionId, DEFAULT_KNOWN_HOSTS_FILE};
 
 pub const DEFAULT_CERT_VERIFIER_BEHAVIOUR: CertVerifierBehaviour =
     CertVerifierBehaviour::ImmediateAction(CertVerifierAction::AbortConnection);
@@ -211,7 +211,7 @@ impl rustls::client::ServerCertVerifier for SkipServerVerification {
 pub(crate) struct TofuServerVerification {
     store: CertStore,
     verifier_behaviour: HashMap<CertVerificationStatus, CertVerifierBehaviour>,
-    to_sync_client: mpsc::Sender<InternalAsyncMessage>,
+    to_sync_client: mpsc::Sender<ClientAsyncMessage>,
 
     /// If present, the file where new fingerprints should be stored
     hosts_file: Option<String>,
@@ -221,7 +221,7 @@ impl TofuServerVerification {
     pub(crate) fn new(
         store: CertStore,
         verifier_behaviour: HashMap<CertVerificationStatus, CertVerifierBehaviour>,
-        to_sync_client: mpsc::Sender<InternalAsyncMessage>,
+        to_sync_client: mpsc::Sender<ClientAsyncMessage>,
         hosts_file: Option<String>,
     ) -> Arc<Self> {
         Arc::new(Self {
@@ -248,7 +248,7 @@ impl TofuServerVerification {
             CertVerifierBehaviour::RequestClientAction => {
                 let (action_sender, cert_action_recv) = oneshot::channel::<CertVerifierAction>();
                 self.to_sync_client
-                    .try_send(InternalAsyncMessage::CertificateInteractionRequest {
+                    .try_send(ClientAsyncMessage::CertificateInteractionRequest {
                         status: status.clone(),
                         info: cert_info.clone(),
                         action_sender,
@@ -273,12 +273,12 @@ impl TofuServerVerification {
     ) -> Result<rustls::client::ServerCertVerified, rustls::Error> {
         match action {
             CertVerifierAction::AbortConnection => {
-                match self.to_sync_client.try_send(
-                    InternalAsyncMessage::CertificateConnectionAbort {
+                match self
+                    .to_sync_client
+                    .try_send(ClientAsyncMessage::CertificateConnectionAbort {
                         status: status,
                         cert_info,
-                    },
-                ) {
+                    }) {
                     Ok(_) => Err(rustls::Error::InvalidCertificateData(format!(
                         "CertVerifierAction requested to abort the connection"
                     ))),
@@ -304,7 +304,7 @@ impl TofuServerVerification {
                 // In all cases raise an event containing the new certificate entry
                 match self
                     .to_sync_client
-                    .try_send(InternalAsyncMessage::CertificateTrustUpdate(cert_info))
+                    .try_send(ClientAsyncMessage::CertificateTrustUpdate(cert_info))
                 {
                     Ok(_) => Ok(rustls::client::ServerCertVerified::assertion()),
                     Err(_) => Err(rustls::Error::General(format!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,12 @@ mod tests {
         ChatMessage(String),
     }
 
+    ///////////////////////////////////////////////////////////
+    ///                                                     ///
+    ///                        Test                         ///
+    ///                                                     ///
+    ///////////////////////////////////////////////////////////
+
     #[test]
     fn connection_with_two_apps() {
         let port = 6000; // TODO Use port 0 and retrieve the port used by the server.
@@ -164,6 +170,12 @@ mod tests {
         }
     }
 
+    ///////////////////////////////////////////////////////////
+    ///                                                     ///
+    ///                        Test                         ///
+    ///                                                     ///
+    ///////////////////////////////////////////////////////////
+
     #[test]
     fn trust_on_first_use() {
         // TOFU With default parameters
@@ -230,14 +242,16 @@ mod tests {
         // Client connects with empty cert store
         {
             let mut client = client_app.world.resource_mut::<Client>();
-            client.open_connection(
-                default_client_configuration(port),
-                CertificateVerificationMode::TrustOnFirstUse(
-                    client::certificate::TrustOnFirstUseConfig {
-                        ..Default::default()
-                    },
-                ),
-            );
+            client
+                .open_connection(
+                    default_client_configuration(port),
+                    CertificateVerificationMode::TrustOnFirstUse(
+                        client::certificate::TrustOnFirstUseConfig {
+                            ..Default::default()
+                        },
+                    ),
+                )
+                .unwrap();
         }
 
         // Let the async runtime connection connect.
@@ -285,14 +299,16 @@ mod tests {
                 .close_all_connections()
                 .expect("Failed to close connections on the client");
 
-            client.open_connection(
-                default_client_configuration(port),
-                CertificateVerificationMode::TrustOnFirstUse(
-                    client::certificate::TrustOnFirstUseConfig {
-                        ..Default::default()
-                    },
-                ),
-            );
+            client
+                .open_connection(
+                    default_client_configuration(port),
+                    CertificateVerificationMode::TrustOnFirstUse(
+                        client::certificate::TrustOnFirstUseConfig {
+                            ..Default::default()
+                        },
+                    ),
+                )
+                .unwrap();
         }
 
         // Let the async runtime connection connect.
@@ -345,14 +361,16 @@ mod tests {
         // Client reconnects with its cert store containing the previously store certificate fingerprint
         {
             let mut client = client_app.world.resource_mut::<Client>();
-            client.open_connection(
-                default_client_configuration(port),
-                CertificateVerificationMode::TrustOnFirstUse(
-                    client::certificate::TrustOnFirstUseConfig {
-                        ..Default::default()
-                    },
-                ),
-            );
+            client
+                .open_connection(
+                    default_client_configuration(port),
+                    CertificateVerificationMode::TrustOnFirstUse(
+                        client::certificate::TrustOnFirstUseConfig {
+                            ..Default::default()
+                        },
+                    ),
+                )
+                .unwrap();
         }
 
         // Let the async runtime connection connect.
@@ -436,6 +454,12 @@ mod tests {
             .expect("Failed to remove default known hosts file");
     }
 
+    ///////////////////////////////////////////////////////////
+    ///                                                     ///
+    ///                  Test utilities                     ///
+    ///                                                     ///
+    ///////////////////////////////////////////////////////////
+
     fn build_client_app() -> App {
         let mut client_app = App::new();
         client_app
@@ -463,10 +487,12 @@ mod tests {
     }
 
     fn start_simple_connection(mut client: ResMut<Client>, port: Res<Port>) {
-        client.open_connection(
-            default_client_configuration(port.0),
-            CertificateVerificationMode::SkipVerification,
-        );
+        client
+            .open_connection(
+                default_client_configuration(port.0),
+                CertificateVerificationMode::SkipVerification,
+            )
+            .unwrap();
     }
 
     fn start_listening(mut server: ResMut<Server>, port: Res<Port>) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,7 +219,7 @@ mod tests {
         // Server listens with a cert loaded from a file
         {
             let mut server = server_app.world.resource_mut::<Server>();
-            let server_cert = server
+            let (server_cert, _) = server
                 .start_endpoint(
                     ServerConfigurationData::new(
                         SERVER_HOST.to_string(),
@@ -349,7 +349,7 @@ mod tests {
         // Let the endpoint fully stop.
         sleep(Duration::from_secs_f32(0.1));
 
-        let server_cert = server_app
+        let (server_cert, _) = server_app
             .world
             .resource_mut::<Server>()
             .start_endpoint(

--- a/src/server.rs
+++ b/src/server.rs
@@ -273,7 +273,7 @@ impl Endpoint {
         match self.clients.remove(&client_id) {
             Some(client_connection) => match client_connection.close_sender.send(()) {
                 Ok(_) => Ok(()),
-                Err(_) => Err(QuinnetError::InternalChannelClosed),
+                Err(_) => Err(QuinnetError::ClientAlreadyDisconnected(client_id)),
             },
             None => Err(QuinnetError::UnknownClient(client_id)),
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,26 +1,35 @@
-use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    net::SocketAddr,
+    sync::Arc,
+    time::Duration,
+};
 
 use bevy::prelude::*;
 use bytes::Bytes;
-use futures::sink::SinkExt;
 use futures_util::StreamExt;
-use quinn::{Endpoint as QuinnEndpoint, SendStream, ServerConfig};
-use quinn_proto::VarInt;
+use quinn::{ConnectionError, Endpoint as QuinnEndpoint, ServerConfig};
 use serde::Deserialize;
 use tokio::{
     runtime,
     sync::{
         broadcast::{self},
-        mpsc::{self, error::TryRecvError},
+        mpsc::{
+            self,
+            error::{TryRecvError, TrySendError},
+        },
     },
     task::JoinSet,
 };
-use tokio_util::codec::{FramedRead, FramedWrite, LengthDelimitedCodec};
+use tokio_util::codec::{FramedRead, LengthDelimitedCodec};
 
 use crate::{
     server::certificate::retrieve_certificate,
     shared::{
-        channel::{ChannelAsyncMessage, ChannelSyncMessage},
+        channel::{
+            channels_task, get_channel_id_from_type, Channel, ChannelAsyncMessage, ChannelId,
+            ChannelSyncMessage, ChannelType, MultiChannelId,
+        },
         AsyncRuntime, ClientId, QuinnetError, DEFAULT_KEEP_ALIVE_INTERVAL_S,
         DEFAULT_KILL_MESSAGE_QUEUE_SIZE, DEFAULT_MESSAGE_QUEUE_SIZE,
     },
@@ -90,30 +99,76 @@ pub struct ClientPayload {
 }
 
 #[derive(Debug)]
-pub(crate) enum InternalAsyncMessage {
+pub(crate) enum ServerAsyncMessage {
     ClientConnected(ClientConnection),
-    ClientLostConnection(ClientId),
+    ClientConnectionClosed(ClientId, ConnectionError),
 }
 
 #[derive(Debug, Clone)]
-pub(crate) enum InternalSyncMessage {
+pub(crate) enum ServerSyncMessage {
     ClientConnectedAck(ClientId),
 }
 
 #[derive(Debug)]
 pub(crate) struct ClientConnection {
     client_id: ClientId,
-    sender: mpsc::Sender<Bytes>,
+    channels: HashMap<ChannelId, Channel>,
     close_sender: broadcast::Sender<()>,
+
+    pub(crate) to_channels_send: mpsc::Sender<ChannelSyncMessage>,
+    pub(crate) from_channels_recv: mpsc::Receiver<ChannelAsyncMessage>,
+}
+
+impl ClientConnection {
+    /// Immediately prevents new messages from being sent on the channel and signal the channel to closes all its background tasks.
+    /// Before trully closing, the channel will wait for all buffered messages to be properly sent according to the channel type.
+    /// Can fail if the [ChannelId] is unknown, or if the channel is already closed.
+    pub(crate) fn close_channel(&mut self, channel_id: ChannelId) -> Result<(), QuinnetError> {
+        match self.channels.remove(&channel_id) {
+            Some(channel) => channel.close(),
+            None => Err(QuinnetError::UnknownChannel(channel_id)),
+        }
+    }
+
+    pub(crate) fn create_channel(
+        &mut self,
+        channel_id: ChannelId,
+    ) -> Result<ChannelId, QuinnetError> {
+        let (bytes_to_channel_send, bytes_to_channel_recv) =
+            mpsc::channel::<Bytes>(DEFAULT_MESSAGE_QUEUE_SIZE);
+        let (channel_close_send, channel_close_recv) =
+            mpsc::channel(DEFAULT_KILL_MESSAGE_QUEUE_SIZE);
+
+        match self
+            .to_channels_send
+            .try_send(ChannelSyncMessage::CreateChannel {
+                channel_id,
+                bytes_to_channel_recv,
+                channel_close_recv,
+            }) {
+            Ok(_) => {
+                let channel = Channel::new(bytes_to_channel_send, channel_close_send);
+                self.channels.insert(channel_id, channel);
+                Ok(channel_id)
+            }
+            Err(err) => match err {
+                TrySendError::Full(_) => Err(QuinnetError::FullQueue),
+                TrySendError::Closed(_) => Err(QuinnetError::InternalChannelClosed),
+            },
+        }
+    }
 }
 
 pub struct Endpoint {
     clients: HashMap<ClientId, ClientConnection>,
-    payloads_recv: mpsc::Receiver<ClientPayload>,
+    channels: HashSet<ChannelId>,
+    default_channel: Option<ChannelId>,
+    last_gen_id: MultiChannelId,
+    payloads_from_clients_recv: mpsc::Receiver<ClientPayload>,
     close_sender: broadcast::Sender<()>,
 
-    pub(crate) from_async_server_recv: mpsc::Receiver<InternalAsyncMessage>,
-    pub(crate) to_async_server_send: broadcast::Sender<InternalSyncMessage>,
+    pub(crate) from_async_server_recv: mpsc::Receiver<ServerAsyncMessage>,
+    pub(crate) to_async_server_send: broadcast::Sender<ServerSyncMessage>,
 }
 
 impl Endpoint {
@@ -139,119 +194,8 @@ impl Endpoint {
         }
     }
 
-    pub fn send_message<T: serde::Serialize>(
-        &mut self,
-        client_id: ClientId,
-        message: T,
-    ) -> Result<(), QuinnetError> {
-        match bincode::serialize(&message) {
-            Ok(payload) => Ok(self.send_payload(client_id, payload)?),
-            Err(_) => Err(QuinnetError::Serialization),
-        }
-    }
-
-    pub fn try_send_message<T: serde::Serialize>(&mut self, client_id: ClientId, message: T) {
-        match self.send_message(client_id, message) {
-            Ok(_) => {}
-            Err(err) => error!("try_send_message: {}", err),
-        }
-    }
-
-    pub fn send_group_message<'a, I: Iterator<Item = &'a ClientId>, T: serde::Serialize>(
-        &self,
-        client_ids: I,
-        message: T,
-    ) -> Result<(), QuinnetError> {
-        match bincode::serialize(&message) {
-            Ok(payload) => {
-                for id in client_ids {
-                    self.send_payload(*id, payload.clone())?;
-                }
-                Ok(())
-            }
-            Err(_) => Err(QuinnetError::Serialization),
-        }
-    }
-
-    pub fn try_send_group_message<'a, I: Iterator<Item = &'a ClientId>, T: serde::Serialize>(
-        &self,
-        client_ids: I,
-        message: T,
-    ) {
-        match self.send_group_message(client_ids, message) {
-            Ok(_) => {}
-            Err(err) => error!("try_send_group_message: {}", err),
-        }
-    }
-
-    pub fn broadcast_message<T: serde::Serialize>(&self, message: T) -> Result<(), QuinnetError> {
-        match bincode::serialize(&message) {
-            Ok(payload) => Ok(self.broadcast_payload(payload)?),
-            Err(_) => Err(QuinnetError::Serialization),
-        }
-    }
-
-    pub fn try_broadcast_message<T: serde::Serialize>(&self, message: T) {
-        match self.broadcast_message(message) {
-            Ok(_) => {}
-            Err(err) => error!("try_broadcast_message: {}", err),
-        }
-    }
-
-    pub fn broadcast_payload<T: Into<Bytes> + Clone>(
-        &self,
-        payload: T,
-    ) -> Result<(), QuinnetError> {
-        for (_, client_connection) in self.clients.iter() {
-            match client_connection.sender.try_send(payload.clone().into()) {
-                Ok(_) => {}
-                Err(err) => match err {
-                    mpsc::error::TrySendError::Full(_) => return Err(QuinnetError::FullQueue),
-                    mpsc::error::TrySendError::Closed(_) => {
-                        return Err(QuinnetError::InternalChannelClosed)
-                    }
-                },
-            };
-        }
-        Ok(())
-    }
-
-    pub fn try_broadcast_payload<T: Into<Bytes> + Clone>(&self, payload: T) {
-        match self.broadcast_payload(payload) {
-            Ok(_) => {}
-            Err(err) => error!("try_broadcast_payload: {}", err),
-        }
-    }
-
-    pub fn send_payload<T: Into<Bytes>>(
-        &self,
-        client_id: ClientId,
-        payload: T,
-    ) -> Result<(), QuinnetError> {
-        if let Some(client) = self.clients.get(&client_id) {
-            match client.sender.try_send(payload.into()) {
-                Ok(_) => Ok(()),
-                Err(err) => match err {
-                    mpsc::error::TrySendError::Full(_) => Err(QuinnetError::FullQueue),
-                    mpsc::error::TrySendError::Closed(_) => {
-                        Err(QuinnetError::InternalChannelClosed)
-                    }
-                },
-            }
-        } else {
-            Err(QuinnetError::UnknownClient(client_id))
-        }
-    }
-
-    pub fn try_send_payload<T: Into<Bytes>>(&self, client_id: ClientId, payload: T) {
-        match self.send_payload(client_id, payload) {
-            Ok(_) => {}
-            Err(err) => error!("try_send_payload: {}", err),
-        }
-    }
-
     pub fn receive_payload(&mut self) -> Result<Option<ClientPayload>, QuinnetError> {
-        match self.payloads_recv.try_recv() {
+        match self.payloads_from_clients_recv.try_recv() {
             Ok(msg) => Ok(Some(msg)),
             Err(err) => match err {
                 TryRecvError::Empty => Ok(None),
@@ -270,6 +214,220 @@ impl Endpoint {
         }
     }
 
+    pub fn send_message<T: serde::Serialize>(
+        &mut self,
+        client_id: ClientId,
+        message: T,
+    ) -> Result<(), QuinnetError> {
+        match self.default_channel {
+            Some(channel) => self.send_message_on(client_id, channel, message),
+            None => Err(QuinnetError::NoDefaultChannel),
+        }
+    }
+
+    pub fn send_message_on<T: serde::Serialize>(
+        &mut self,
+        client_id: ClientId,
+        channel_id: ChannelId,
+        message: T,
+    ) -> Result<(), QuinnetError> {
+        match bincode::serialize(&message) {
+            Ok(payload) => Ok(self.send_payload_on(client_id, channel_id, payload)?),
+            Err(_) => Err(QuinnetError::Serialization),
+        }
+    }
+
+    pub fn try_send_message<T: serde::Serialize>(&mut self, client_id: ClientId, message: T) {
+        match self.send_message(client_id, message) {
+            Ok(_) => {}
+            Err(err) => error!("try_send_message: {}", err),
+        }
+    }
+
+    pub fn try_send_message_on<T: serde::Serialize>(
+        &mut self,
+        client_id: ClientId,
+        channel_id: ChannelId,
+        message: T,
+    ) {
+        match self.send_message_on(client_id, channel_id, message) {
+            Ok(_) => {}
+            Err(err) => error!("try_send_message: {}", err),
+        }
+    }
+
+    pub fn send_group_message<'a, I: Iterator<Item = &'a ClientId>, T: serde::Serialize>(
+        &self,
+        client_ids: I,
+        message: T,
+    ) -> Result<(), QuinnetError> {
+        match self.default_channel {
+            Some(channel) => self.send_group_message_on(client_ids, channel, message),
+            None => Err(QuinnetError::NoDefaultChannel),
+        }
+    }
+
+    pub fn send_group_message_on<'a, I: Iterator<Item = &'a ClientId>, T: serde::Serialize>(
+        &self,
+        client_ids: I,
+        channel_id: ChannelId,
+        message: T,
+    ) -> Result<(), QuinnetError> {
+        match bincode::serialize(&message) {
+            Ok(payload) => {
+                for id in client_ids {
+                    self.send_payload_on(*id, channel_id, payload.clone())?;
+                }
+                Ok(())
+            }
+            Err(_) => Err(QuinnetError::Serialization),
+        }
+    }
+
+    pub fn try_send_group_message<'a, I: Iterator<Item = &'a ClientId>, T: serde::Serialize>(
+        &self,
+        client_ids: I,
+        message: T,
+    ) {
+        match self.send_group_message(client_ids, message) {
+            Ok(_) => {}
+            Err(err) => error!("try_send_group_message: {}", err),
+        }
+    }
+
+    pub fn try_send_group_message_on<'a, I: Iterator<Item = &'a ClientId>, T: serde::Serialize>(
+        &self,
+        client_ids: I,
+        channel_id: ChannelId,
+        message: T,
+    ) {
+        match self.send_group_message_on(client_ids, channel_id, message) {
+            Ok(_) => {}
+            Err(err) => error!("try_send_group_message: {}", err),
+        }
+    }
+
+    pub fn broadcast_message<T: serde::Serialize>(&self, message: T) -> Result<(), QuinnetError> {
+        match self.default_channel {
+            Some(channel) => self.broadcast_message_on(channel, message),
+            None => Err(QuinnetError::NoDefaultChannel),
+        }
+    }
+
+    pub fn broadcast_message_on<T: serde::Serialize>(
+        &self,
+        channel_id: ChannelId,
+        message: T,
+    ) -> Result<(), QuinnetError> {
+        match bincode::serialize(&message) {
+            Ok(payload) => Ok(self.broadcast_payload_on(channel_id, payload)?),
+            Err(_) => Err(QuinnetError::Serialization),
+        }
+    }
+
+    pub fn try_broadcast_message<T: serde::Serialize>(&self, message: T) {
+        match self.broadcast_message(message) {
+            Ok(_) => {}
+            Err(err) => error!("try_broadcast_message: {}", err),
+        }
+    }
+
+    pub fn try_broadcast_message_on<T: serde::Serialize>(&self, message: T, channel_id: ChannelId) {
+        match self.broadcast_message_on(channel_id, message) {
+            Ok(_) => {}
+            Err(err) => error!("try_broadcast_message: {}", err),
+        }
+    }
+
+    pub fn broadcast_payload<T: Into<Bytes> + Clone>(
+        &self,
+        payload: T,
+    ) -> Result<(), QuinnetError> {
+        match self.default_channel {
+            Some(channel) => self.broadcast_payload_on(channel, payload),
+            None => Err(QuinnetError::NoDefaultChannel),
+        }
+    }
+
+    pub fn broadcast_payload_on<T: Into<Bytes> + Clone>(
+        &self,
+        channel_id: ChannelId,
+        payload: T,
+    ) -> Result<(), QuinnetError> {
+        let payload = payload.into();
+        for (_, client_connection) in self.clients.iter() {
+            match client_connection.channels.get(&channel_id) {
+                Some(channel) => channel.send_payload(payload.clone())?,
+                None => return Err(QuinnetError::UnknownChannel(channel_id)),
+            };
+        }
+        Ok(())
+    }
+
+    pub fn try_broadcast_payload<T: Into<Bytes> + Clone>(&self, payload: T) {
+        match self.broadcast_payload(payload) {
+            Ok(_) => {}
+            Err(err) => error!("try_broadcast_payload: {}", err),
+        }
+    }
+
+    pub fn try_broadcast_payload_on<T: Into<Bytes> + Clone>(
+        &self,
+        channel_id: ChannelId,
+        payload: T,
+    ) {
+        match self.broadcast_payload_on(channel_id, payload) {
+            Ok(_) => {}
+            Err(err) => error!("try_broadcast_payload_on: {}", err),
+        }
+    }
+
+    pub fn send_payload<T: Into<Bytes>>(
+        &self,
+        client_id: ClientId,
+        payload: T,
+    ) -> Result<(), QuinnetError> {
+        match self.default_channel {
+            Some(channel) => self.send_payload_on(client_id, channel, payload),
+            None => Err(QuinnetError::NoDefaultChannel),
+        }
+    }
+
+    pub fn send_payload_on<T: Into<Bytes>>(
+        &self,
+        client_id: ClientId,
+        channel_id: ChannelId,
+        payload: T,
+    ) -> Result<(), QuinnetError> {
+        if let Some(client_connection) = self.clients.get(&client_id) {
+            match client_connection.channels.get(&channel_id) {
+                Some(channel) => channel.send_payload(payload),
+                None => return Err(QuinnetError::UnknownChannel(channel_id)),
+            }
+        } else {
+            Err(QuinnetError::UnknownClient(client_id))
+        }
+    }
+
+    pub fn try_send_payload<T: Into<Bytes>>(&self, client_id: ClientId, payload: T) {
+        match self.send_payload(client_id, payload) {
+            Ok(_) => {}
+            Err(err) => error!("try_send_payload: {}", err),
+        }
+    }
+
+    pub fn try_send_payload_on<T: Into<Bytes>>(
+        &self,
+        client_id: ClientId,
+        channel_id: ChannelId,
+        payload: T,
+    ) {
+        match self.send_payload_on(client_id, channel_id, payload) {
+            Ok(_) => {}
+            Err(err) => error!("try_send_payload_on: {}", err),
+        }
+    }
+
     pub fn disconnect_client(&mut self, client_id: ClientId) -> Result<(), QuinnetError> {
         match self.clients.remove(&client_id) {
             Some(client_connection) => match client_connection.close_sender.send(()) {
@@ -280,6 +438,16 @@ impl Endpoint {
         }
     }
 
+    pub fn try_disconnect_client(&mut self, client_id: ClientId) {
+        match self.disconnect_client(client_id) {
+            Ok(_) => (),
+            Err(err) => error!(
+                "Failed to properly disconnect client {}: {}",
+                client_id, err
+            ),
+        }
+    }
+
     pub fn disconnect_all_clients(&mut self) -> Result<(), QuinnetError> {
         for client_id in self.clients.keys().cloned().collect::<Vec<ClientId>>() {
             self.disconnect_client(client_id)?;
@@ -287,10 +455,75 @@ impl Endpoint {
         Ok(())
     }
 
-    pub(crate) fn close_incoming_connections_handler(&mut self) -> Result<(), QuinnetError> {
+    pub fn open_channel(&mut self, channel_type: ChannelType) -> Result<ChannelId, QuinnetError> {
+        let channel_id = get_channel_id_from_type(channel_type, || {
+            self.last_gen_id += 1;
+            self.last_gen_id
+        });
+        match self.channels.contains(&channel_id) {
+            true => Ok(channel_id),
+            false => self.create_channel(channel_id),
+        }
+    }
+
+    pub fn close_channel(&mut self, channel_id: ChannelId) -> Result<(), QuinnetError> {
+        match self.channels.remove(&channel_id) {
+            true => {
+                if Some(channel_id) == self.default_channel {
+                    self.default_channel = None;
+                }
+                for (_, connection) in self.clients.iter_mut() {
+                    connection.close_channel(channel_id)?;
+                }
+                Ok(())
+            }
+            false => Err(QuinnetError::UnknownChannel(channel_id)),
+        }
+    }
+
+    fn open_default_channels(&mut self) -> Result<ChannelId, QuinnetError> {
+        self.open_channel(ChannelType::OrderedReliable)?;
+        self.open_channel(ChannelType::UnorderedReliable)?;
+        self.open_channel(ChannelType::Unreliable)
+    }
+
+    fn create_channel(&mut self, channel_id: ChannelId) -> Result<ChannelId, QuinnetError> {
+        for (_, client_connection) in self.clients.iter_mut() {
+            client_connection.create_channel(channel_id)?;
+        }
+        self.channels.insert(channel_id);
+        if self.default_channel.is_none() {
+            self.default_channel = Some(channel_id);
+        }
+        Ok(channel_id)
+    }
+
+    fn close_incoming_connections_handler(&mut self) -> Result<(), QuinnetError> {
         match self.close_sender.send(()) {
             Ok(_) => Ok(()),
             Err(_) => Err(QuinnetError::InternalChannelClosed),
+        }
+    }
+
+    fn handle_connection(&mut self, mut connection: ClientConnection) -> Result<(), QuinnetError> {
+        match self.clients.contains_key(&connection.client_id) {
+            true => todo!(),
+            false => {
+                for channel_id in self.channels.iter() {
+                    connection.create_channel(*channel_id)?;
+                }
+
+                match self
+                    .to_async_server_send
+                    .send(ServerSyncMessage::ClientConnectedAck(connection.client_id))
+                {
+                    Ok(_) => {
+                        self.clients.insert(connection.client_id, connection);
+                        Ok(())
+                    }
+                    Err(_) => Err(QuinnetError::InternalChannelClosed),
+                }
+            }
         }
     }
 }
@@ -340,10 +573,9 @@ impl Server {
         let (payloads_from_clients_send, payloads_from_clients_recv) =
             mpsc::channel::<ClientPayload>(DEFAULT_MESSAGE_QUEUE_SIZE);
         let (to_sync_server_send, from_async_server_recv) =
-            mpsc::channel::<InternalAsyncMessage>(DEFAULT_INTERNAL_MESSAGE_CHANNEL_SIZE);
+            mpsc::channel::<ServerAsyncMessage>(DEFAULT_INTERNAL_MESSAGE_CHANNEL_SIZE);
         let (to_async_server_send, from_sync_server_recv) =
-            broadcast::channel::<InternalSyncMessage>(DEFAULT_INTERNAL_MESSAGE_CHANNEL_SIZE);
-        // Create a close channel for this endpoint
+            broadcast::channel::<ServerSyncMessage>(DEFAULT_INTERNAL_MESSAGE_CHANNEL_SIZE);
         let (endpoint_close_send, endpoint_close_recv) =
             broadcast::channel(DEFAULT_KILL_MESSAGE_QUEUE_SIZE);
 
@@ -361,13 +593,20 @@ impl Server {
             .await;
         });
 
-        self.endpoint = Some(Endpoint {
-            clients: HashMap::new(),
-            payloads_recv: payloads_from_clients_recv,
-            close_sender: endpoint_close_send,
-            from_async_server_recv,
-            to_async_server_send: to_async_server_send.clone(),
-        });
+        {
+            let mut endpoint = Endpoint {
+                clients: HashMap::new(),
+                channels: HashSet::new(),
+                default_channel: None,
+                last_gen_id: 0,
+                payloads_from_clients_recv,
+                close_sender: endpoint_close_send,
+                from_async_server_recv,
+                to_async_server_send: to_async_server_send.clone(),
+            };
+            endpoint.open_default_channels()?;
+            self.endpoint = Some(endpoint);
+        }
 
         Ok(server_cert)
     }
@@ -394,9 +633,9 @@ impl Server {
 async fn endpoint_task(
     endpoint_config: ServerConfig,
     endpoint_adr: SocketAddr,
-    to_sync_server_send: mpsc::Sender<InternalAsyncMessage>,
+    to_sync_server_send: mpsc::Sender<ServerAsyncMessage>,
     mut endpoint_close_recv: broadcast::Receiver<()>,
-    mut from_sync_server_recv: broadcast::Receiver<InternalSyncMessage>,
+    from_sync_server_recv: broadcast::Receiver<ServerSyncMessage>,
     payloads_from_clients_send: mpsc::Sender<ClientPayload>,
 ) {
     let mut client_gen_id: ClientId = 0;
@@ -418,182 +657,108 @@ async fn endpoint_task(
                         let client_id = client_gen_id;
                         client_id_mappings.insert(connection.stable_id(), client_id);
 
-                        handle_client_connection(
-                            connection,
-                            client_id,
-                            &to_sync_server_send,
-                            &mut from_sync_server_recv,
-                            payloads_from_clients_send.clone(),
-                        )
-                        .await;
+                        {
+                            let to_sync_server_send = to_sync_server_send.clone();
+                            let from_sync_server_recv = from_sync_server_recv.resubscribe();
+                            let payloads_from_clients_send = payloads_from_clients_send.clone();
+                            tokio::spawn(async move {
+                                client_connection_task(
+                                    connection,
+                                    client_id,
+                                    to_sync_server_send,
+                                    from_sync_server_recv,
+                                    payloads_from_clients_send,
+                                )
+                                .await
+                            });
+                        }
                     },
                 }
-
             }
         } => {}
     }
 }
 
-async fn handle_client_connection(
+async fn client_connection_task(
     connection: quinn::Connection,
     client_id: ClientId,
-    to_sync_server_send: &mpsc::Sender<InternalAsyncMessage>,
-    from_sync_server_recv: &mut broadcast::Receiver<InternalSyncMessage>,
+    to_sync_server_send: mpsc::Sender<ServerAsyncMessage>,
+    mut from_sync_server_recv: broadcast::Receiver<ServerSyncMessage>,
     payloads_from_clients_send: mpsc::Sender<ClientPayload>,
 ) {
     info!(
-        "New connection from {}, client_id: {}, stable_id : {}",
+        "New connection from {}, client_id: {}",
         connection.remote_address(),
-        client_id,
-        connection.stable_id()
+        client_id
     );
 
     let (client_close_send, client_close_recv) =
         broadcast::channel(DEFAULT_KILL_MESSAGE_QUEUE_SIZE);
-
-    // Create an ordered reliable send channel for this client
-    let (to_client_sender, to_client_receiver) = mpsc::channel::<Bytes>(DEFAULT_MESSAGE_QUEUE_SIZE);
-
-    let _client_sender = {
-        let to_sync_server_send_clone = to_sync_server_send.clone();
-        let close_sender_clone = client_close_send.clone();
-        let connection_clone = connection.clone();
-        tokio::spawn(async move {
-            client_sender_task(
-                client_id,
-                connection_clone,
-                to_client_receiver,
-                client_close_recv,
-                close_sender_clone,
-                to_sync_server_send_clone,
-            )
-            .await
-        })
-    };
+    let (from_channels_send, from_channels_recv) =
+        mpsc::channel::<ChannelAsyncMessage>(DEFAULT_INTERNAL_MESSAGE_CHANNEL_SIZE);
+    let (to_channels_send, to_channels_recv) =
+        mpsc::channel::<ChannelSyncMessage>(DEFAULT_INTERNAL_MESSAGE_CHANNEL_SIZE);
 
     // Signal the sync server of this new connection
     to_sync_server_send
-        .send(InternalAsyncMessage::ClientConnected(ClientConnection {
+        .send(ServerAsyncMessage::ClientConnected(ClientConnection {
             client_id: client_id,
-            sender: to_client_sender,
+            channels: HashMap::new(),
             close_sender: client_close_send.clone(),
+            from_channels_recv,
+            to_channels_send,
         }))
         .await
         .expect("Failed to signal connection to sync client");
 
     // Wait for the sync server to acknowledge the connection before spawning reception tasks.
-    while let Ok(InternalSyncMessage::ClientConnectedAck(id)) = from_sync_server_recv.recv().await {
+    while let Ok(ServerSyncMessage::ClientConnectedAck(id)) = from_sync_server_recv.recv().await {
         if id == client_id {
             break;
         }
     }
 
-    let _client_close_wait = {
+    // Spawn a task to listen for the underlying connection being closed
+    {
         let conn = connection.clone();
-        let close_sender = client_close_send.clone();
         let to_sync_server = to_sync_server_send.clone();
         tokio::spawn(async move {
             let conn_err = conn.closed().await;
-            info!("Client {} disconnected: {}", client_id, conn_err);
-            close_sender.send(()).ok();
+            info!("Client {} connection closed: {}", client_id, conn_err);
             to_sync_server
-                .send(InternalAsyncMessage::ClientLostConnection(client_id))
+                .send(ServerAsyncMessage::ClientConnectionClosed(
+                    client_id, conn_err,
+                ))
                 .await
                 .expect("Failed to signal connection lost to sync server");
         });
     };
 
     // Spawn a task to listen for streams opened by this client
-    let _client_receiver = tokio::spawn(async move {
-        client_receiver_task(
-            client_id,
+    {
+        let conn = connection.clone();
+        let client_close_recv = client_close_recv.resubscribe();
+        tokio::spawn(async move {
+            client_receiver_task(
+                client_id,
+                conn,
+                client_close_recv,
+                payloads_from_clients_send,
+            )
+            .await
+        });
+    }
+
+    // Spawn a task to handle channels for this client
+    tokio::spawn(async move {
+        channels_task(
             connection,
-            client_close_send.subscribe(),
-            payloads_from_clients_send,
+            client_close_recv,
+            to_channels_recv,
+            from_channels_send,
         )
         .await
     });
-}
-
-async fn client_sender_task(
-    client_id: ClientId,
-    connection: quinn::Connection,
-    mut to_client_receiver: tokio::sync::mpsc::Receiver<Bytes>,
-    mut client_close_recv: tokio::sync::broadcast::Receiver<()>,
-    close_sender: tokio::sync::broadcast::Sender<()>,
-    to_sync_server_send: mpsc::Sender<InternalAsyncMessage>,
-) {
-    let send_stream = connection.open_uni().await.expect(
-        format!(
-            "Failed to open unidirectional send stream for client: {}",
-            client_id
-        )
-        .as_str(),
-    );
-
-    let mut framed_send_stream = FramedWrite::new(send_stream, LengthDelimitedCodec::new());
-
-    tokio::select! {
-        _ = client_close_recv.recv() => {
-            trace!("Unidirectional send stream forced to disconnected for client: {}", client_id)
-        }
-        _ = async {
-            while let Some(msg_bytes) = to_client_receiver.recv().await {
-                send_msg(
-                    client_id,
-                    &close_sender,
-                    &to_sync_server_send,
-                    &mut framed_send_stream,
-                    msg_bytes,
-                )
-                .await
-            }
-        } => {}
-    }
-    while let Ok(msg_bytes) = to_client_receiver.try_recv() {
-        if let Err(err) = framed_send_stream.send(msg_bytes.clone()).await {
-            error!("Error while sending to client {}: {}", client_id, err);
-        };
-    }
-    if let Err(err) = framed_send_stream.flush().await {
-        error!(
-            "Error while flushing stream to client {}: {}",
-            client_id, err
-        );
-    }
-    if let Err(err) = framed_send_stream.into_inner().finish().await {
-        error!(
-            "Failed to shutdown stream gracefully for client {}: {}",
-            client_id, err
-        );
-    }
-    connection.close(VarInt::from_u32(0), "closed".as_bytes());
-}
-
-async fn send_msg(
-    client_id: ClientId,
-    close_sender: &tokio::sync::broadcast::Sender<()>,
-    to_sync_server: &mpsc::Sender<InternalAsyncMessage>,
-    framed_send_stream: &mut FramedWrite<SendStream, LengthDelimitedCodec>,
-    msg_bytes: Bytes,
-) {
-    // TODO Perf: Batch frames for a send_all
-    if let Err(err) = framed_send_stream.send(msg_bytes.clone()).await {
-        error!("Error while sending to client {}: {}", client_id, err);
-        error!("Client {} seems disconnected, closing resources", client_id);
-        // Emit ClientLostConnection to properly update the server about this client state.
-        // Raise ClientLostConnection event before emitting a close signal because we have no guarantee to continue this async execution after the close signal has been processed.
-        to_sync_server
-            .send(InternalAsyncMessage::ClientLostConnection(client_id))
-            .await
-            .expect("Failed to signal connection lost to sync server");
-        if let Err(_) = close_sender.send(()) {
-            error!(
-                "Failed to close all client streams & resources for client {}",
-                client_id
-            )
-        }
-    };
 }
 
 async fn client_receiver_task(
@@ -654,24 +819,40 @@ fn update_sync_server(
     if let Some(endpoint) = server.get_endpoint_mut() {
         while let Ok(message) = endpoint.from_async_server_recv.try_recv() {
             match message {
-                InternalAsyncMessage::ClientConnected(connection) => {
+                ServerAsyncMessage::ClientConnected(connection) => {
                     let id = connection.client_id;
-                    endpoint.clients.insert(id, connection);
-                    endpoint
-                        .to_async_server_send
-                        .send(InternalSyncMessage::ClientConnectedAck(id))
-                        .unwrap();
-                    connection_events.send(ConnectionEvent { id: id });
+                    match endpoint.handle_connection(connection) {
+                        Ok(_) => connection_events.send(ConnectionEvent { id }),
+                        Err(_) => error!("Failed to handle connection of client {}", id),
+                    };
                 }
-                InternalAsyncMessage::ClientLostConnection(client_id) => {
-                    match endpoint.clients.remove(&client_id) {
-                        Some(_) => {
+                ServerAsyncMessage::ClientConnectionClosed(client_id, _) => {
+                    match endpoint.clients.contains_key(&client_id) {
+                        true => {
+                            endpoint.try_disconnect_client(client_id);
                             connection_lost_events.send(ConnectionLostEvent { id: client_id })
                         }
-                        None => (),
+                        false => (),
                     }
                 }
             }
+        }
+
+        let mut lost_clients = HashSet::new();
+        for (client_id, connection) in endpoint.clients.iter_mut() {
+            while let Ok(message) = connection.from_channels_recv.try_recv() {
+                match message {
+                    ChannelAsyncMessage::LostConnection => {
+                        if !lost_clients.contains(client_id) {
+                            lost_clients.insert(*client_id);
+                            connection_lost_events.send(ConnectionLostEvent { id: *client_id })
+                        }
+                    }
+                }
+            }
+        }
+        for client_id in lost_clients {
+            endpoint.try_disconnect_client(client_id);
         }
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -481,6 +481,16 @@ impl Endpoint {
         }
     }
 
+    /// Set the default channel
+    pub fn set_default_channel(&mut self, channel_id: ChannelId) {
+        self.default_channel = Some(channel_id);
+    }
+
+    /// Get the default Channel Id
+    pub fn get_default_channel(&self) -> Option<ChannelId> {
+        self.default_channel
+    }
+
     fn open_default_channels(&mut self) -> Result<ChannelId, QuinnetError> {
         self.open_channel(ChannelType::OrderedReliable)?;
         self.open_channel(ChannelType::UnorderedReliable)?;

--- a/src/server.rs
+++ b/src/server.rs
@@ -751,12 +751,15 @@ async fn client_connection_task(
         tokio::spawn(async move {
             let conn_err = conn.closed().await;
             info!("Client {} connection closed: {}", client_id, conn_err);
-            to_sync_server
-                .send(ServerAsyncMessage::ClientConnectionClosed(
-                    client_id, conn_err,
-                ))
-                .await
-                .expect("Failed to signal connection lost to sync server");
+            // If we requested the connection to close, channel may have been closed already.
+            if !to_sync_server.is_closed() {
+                to_sync_server
+                    .send(ServerAsyncMessage::ClientConnectionClosed(
+                        client_id, conn_err,
+                    ))
+                    .await
+                    .expect("Failed to signal connection lost to sync server");
+            }
         });
     };
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -207,7 +207,7 @@ impl Endpoint {
                 Err(err) => match err {
                     mpsc::error::TrySendError::Full(_) => return Err(QuinnetError::FullQueue),
                     mpsc::error::TrySendError::Closed(_) => {
-                        return Err(QuinnetError::ChannelClosed)
+                        return Err(QuinnetError::InternalChannelClosed)
                     }
                 },
             };
@@ -232,7 +232,9 @@ impl Endpoint {
                 Ok(_) => Ok(()),
                 Err(err) => match err {
                     mpsc::error::TrySendError::Full(_) => Err(QuinnetError::FullQueue),
-                    mpsc::error::TrySendError::Closed(_) => Err(QuinnetError::ChannelClosed),
+                    mpsc::error::TrySendError::Closed(_) => {
+                        Err(QuinnetError::InternalChannelClosed)
+                    }
                 },
             }
         } else {
@@ -252,7 +254,7 @@ impl Endpoint {
             Ok(msg) => Ok(Some(msg)),
             Err(err) => match err {
                 TryRecvError::Empty => Ok(None),
-                TryRecvError::Disconnected => Err(QuinnetError::ChannelClosed),
+                TryRecvError::Disconnected => Err(QuinnetError::InternalChannelClosed),
             },
         }
     }
@@ -271,7 +273,7 @@ impl Endpoint {
         match self.clients.remove(&client_id) {
             Some(client_connection) => match client_connection.close_sender.send(()) {
                 Ok(_) => Ok(()),
-                Err(_) => Err(QuinnetError::ChannelClosed),
+                Err(_) => Err(QuinnetError::InternalChannelClosed),
             },
             None => Err(QuinnetError::UnknownClient(client_id)),
         }
@@ -287,7 +289,7 @@ impl Endpoint {
     pub(crate) fn close_incoming_connections_handler(&mut self) -> Result<(), QuinnetError> {
         match self.close_sender.send(()) {
             Ok(_) => Ok(()),
-            Err(_) => Err(QuinnetError::ChannelClosed),
+            Err(_) => Err(QuinnetError::InternalChannelClosed),
         }
     }
 }

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -30,6 +30,8 @@ pub enum QuinnetError {
     ConnectionClosed,
     #[error("Channel with id `{0}` is unknown")]
     UnknownChannel(ChannelId),
+    #[error("The connection has no default channel")]
+    NoDefaultChannel,
     #[error("Endpoint is already closed")]
     EndpointAlreadyClosed,
     #[error("Failed serialization")]

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -10,6 +10,7 @@ pub const DEFAULT_KILL_MESSAGE_QUEUE_SIZE: usize = 10;
 pub const DEFAULT_KEEP_ALIVE_INTERVAL_S: u64 = 4;
 
 pub type ClientId = u64;
+pub type ChannelId = u64;
 
 #[derive(Resource, Deref, DerefMut)]
 pub(crate) struct AsyncRuntime(pub(crate) Runtime);
@@ -27,6 +28,8 @@ pub enum QuinnetError {
     UnknownConnection(ConnectionId),
     #[error("Connection is closed")]
     ConnectionClosed,
+    #[error("Channel with id `{0}` is unknown")]
+    UnknownChannel(ChannelId),
     #[error("Endpoint is already closed")]
     EndpointAlreadyClosed,
     #[error("Failed serialization")]

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -5,12 +5,15 @@ use bevy::prelude::{Deref, DerefMut, Resource};
 use rcgen::RcgenError;
 use tokio::runtime::Runtime;
 
+use self::channel::ChannelId;
+
 pub const DEFAULT_MESSAGE_QUEUE_SIZE: usize = 150;
 pub const DEFAULT_KILL_MESSAGE_QUEUE_SIZE: usize = 10;
 pub const DEFAULT_KEEP_ALIVE_INTERVAL_S: u64 = 4;
 
 pub type ClientId = u64;
-pub type ChannelId = u64;
+
+pub mod channel;
 
 #[derive(Resource, Deref, DerefMut)]
 pub(crate) struct AsyncRuntime(pub(crate) Runtime);

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -27,12 +27,18 @@ pub enum QuinnetError {
     CertificateGenerationFailed(#[from] RcgenError),
     #[error("Client with id `{0}` is unknown")]
     UnknownClient(ClientId),
+    #[error("Client with id `{0}` is already disconnected")]
+    ClientAlreadyDisconnected(ClientId),
     #[error("Connection with id `{0}` is unknown")]
     UnknownConnection(ConnectionId),
-    #[error("Connection is closed")]
+    #[error("Connection is 'disconnected'")]
     ConnectionClosed,
+    #[error("Connection is already closed")]
+    ConnectionAlreadyClosed,
     #[error("Channel with id `{0}` is unknown")]
     UnknownChannel(ChannelId),
+    #[error("Channel is already closed")]
+    ChannelAlreadyClosed,
     #[error("The connection has no default channel")]
     NoDefaultChannel,
     #[error("Endpoint is already closed")]
@@ -43,7 +49,9 @@ pub enum QuinnetError {
     Deserialization,
     #[error("The data could not be sent on the channel because the channel is currently full and sending would require blocking")]
     FullQueue,
-    #[error("The receiving half of the channel was explicitly closed or has been dropped")]
+    #[error(
+        "The receiving half of the internal channel was explicitly closed or has been dropped"
+    )]
     InternalChannelClosed,
     #[error("The hosts file is invalid")]
     InvalidHostFile,

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -44,7 +44,7 @@ pub enum QuinnetError {
     #[error("The data could not be sent on the channel because the channel is currently full and sending would require blocking")]
     FullQueue,
     #[error("The receiving half of the channel was explicitly closed or has been dropped")]
-    ChannelClosed,
+    InternalChannelClosed,
     #[error("The hosts file is invalid")]
     InvalidHostFile,
     #[error("Lock acquisition failure")]

--- a/src/shared/channel.rs
+++ b/src/shared/channel.rs
@@ -1,14 +1,14 @@
+use super::QuinnetError;
 use bevy::prelude::{error, trace};
 use bytes::Bytes;
 use futures::sink::SinkExt;
-use futures_util::StreamExt;
+use quinn::VarInt;
+use std::fmt::Debug;
 use tokio::sync::{
     broadcast,
     mpsc::{self, error::TrySendError},
 };
-use tokio_util::codec::{FramedRead, FramedWrite, LengthDelimitedCodec};
-
-use super::QuinnetError;
+use tokio_util::codec::{FramedWrite, LengthDelimitedCodec};
 
 pub(crate) type OrdRelChannelId = u64;
 
@@ -53,76 +53,112 @@ impl Channel {
     }
 }
 
-// async fn ordered_reliable_channel_task(
-//     connection: quinn::Connection,
-//     to_sync_client: mpsc::Sender<InternalAsyncMessage>,
-//     mut close_receiver: broadcast::Receiver<()>,
-//     mut to_server_receiver: mpsc::Receiver<Bytes>,
+pub(crate) async fn ordered_reliable_channel_task<T: Debug>(
+    connection: quinn::Connection,
+    to_sync_client: mpsc::Sender<T>,
+    on_lost_connection: fn() -> T,
+    mut close_receiver: broadcast::Receiver<()>,
+    mut to_server_receiver: mpsc::Receiver<Bytes>,
+) {
+    let uni_sender = connection
+        .open_uni()
+        .await
+        .expect("Failed to open send stream");
+    let mut frame_sender = FramedWrite::new(uni_sender, LengthDelimitedCodec::new());
+
+    tokio::select! {
+        _ = close_receiver.recv() => {
+            trace!("Ordered Reliable Channel task received a close signal")
+        }
+        _ = async {
+            while let Some(msg_bytes) = to_server_receiver.recv().await {
+                if let Err(err) = frame_sender.send(msg_bytes).await {
+                    // TODO Clean: error handling
+                    error!("Error while sending, {}", err);
+                    // error!("Client seems disconnected, closing resources");
+                    // if let Err(_) = close_sender_clone.send(()) {
+                    //     error!("Failed to close all client streams & resources")
+                    // }
+                    to_sync_client.send(
+                        on_lost_connection())
+                        .await
+                        .expect("Failed to signal connection lost to sync client");
+                }
+            }
+        } => {
+            trace!("Ordered Reliable Channel task ended")
+        }
+    }
+    while let Ok(msg_bytes) = to_server_receiver.try_recv() {
+        if let Err(err) = frame_sender.send(msg_bytes).await {
+            error!("Error while sending, {}", err);
+        }
+    }
+    if let Err(err) = frame_sender.flush().await {
+        error!("Error while flushing stream: {}", err);
+    }
+    if let Err(err) = frame_sender.into_inner().finish().await {
+        error!("Failed to shutdown stream gracefully: {}", err);
+    }
+    todo!("Do not close here, wait for all channels to be flushed");
+    connection.close(VarInt::from_u32(0), "closed".as_bytes());
+}
+
+pub(crate) async fn unordered_reliable_channel_task<T: Debug>(
+    connection: quinn::Connection,
+    to_sync_client: mpsc::Sender<T>,
+    on_lost_connection: fn() -> T,
+    mut close_receiver: broadcast::Receiver<()>,
+    mut to_server_receiver: mpsc::Receiver<Bytes>,
+) {
+    tokio::select! {
+        _ = close_receiver.recv() => {
+            trace!("Unordered Reliable Channel task received a close signal")
+        }
+        _ = async {
+            while let Some(msg_bytes) = to_server_receiver.recv().await {
+                let uni_sender = connection
+                    .open_uni()
+                    .await
+                    .expect("Failed to open send stream");
+                let mut frame_sender = FramedWrite::new(uni_sender, LengthDelimitedCodec::new());
+
+                if let Err(err) = frame_sender.send(msg_bytes).await {
+                    // TODO Clean: error handling
+                    error!("Error while sending, {}", err);
+                    // error!("Client seems disconnected, closing resources");
+                    // if let Err(_) = close_sender_clone.send(()) {
+                    //     error!("Failed to close all client streams & resources")
+                    // }
+                    to_sync_client.send(
+                        on_lost_connection())
+                        .await
+                        .expect("Failed to signal connection lost to sync client");
+                }
+            }
+        } => {
+            trace!("Unordered Reliable Channel task ended")
+        }
+    }
+}
+
+// async fn send_msg(
+//     // close_sender: &tokio::sync::broadcast::Sender<()>,
+//     to_sync_client: &mpsc::Sender<InternalAsyncMessage>,
+//     frame_send: &mut FramedWrite<SendStream, LengthDelimitedCodec>,
+//     msg_bytes: Bytes,
 // ) {
-//     tokio::select! {
-//         _ = close_receiver.recv() => {
-//             trace!("Ordered Reliable Send Channel received a close signal")
-//         }
-//         _ = async {
-//             let uni_sender = connection
-//                 .open_uni()
-//                 .await
-//                 .expect("Failed to open send stream");
-//             let mut frame_sender = FramedWrite::new(uni_sender, LengthDelimitedCodec::new());
-
-//             while let Some(msg_bytes) = to_server_receiver.recv().await {
-//                 if let Err(err) = frame_sender.send(msg_bytes).await {
-//                     // TODO Clean: error handling
-//                     error!("Error while sending, {}", err);
-//                     // error!("Client seems disconnected, closing resources");
-//                     // if let Err(_) = close_sender_clone.send(()) {
-//                     //     error!("Failed to close all client streams & resources")
-//                     // }
-//                     to_sync_client.send(
-//                         InternalAsyncMessage::LostConnection)
-//                         .await
-//                         .expect("Failed to signal connection lost to sync client");
-//                 }
-//             }
-//         } => {
-//             trace!("Ordered Reliable Send Channel ended")
-//         }
-//     }
-// }
-
-// async fn unordered_reliable_channel_task(
-//     connection: quinn::Connection,
-//     to_sync_client: mpsc::Sender<InternalAsyncMessage>,
-//     mut close_receiver: broadcast::Receiver<()>,
-//     mut to_server_receiver: mpsc::Receiver<Bytes>,
-// ) {
-//     tokio::select! {
-//         _ = close_receiver.recv() => {
-//             trace!("Unordered Reliable Send Channel received a close signal")
-//         }
-//         _ = async {
-//             while let Some(msg_bytes) = to_server_receiver.recv().await {
-//                 let uni_sender = connection
-//                     .open_uni()
-//                     .await
-//                     .expect("Failed to open send stream");
-//                 let mut frame_sender = FramedWrite::new(uni_sender, LengthDelimitedCodec::new());
-
-//                 if let Err(err) = frame_sender.send(msg_bytes).await {
-//                     // TODO Clean: error handling
-//                     error!("Error while sending, {}", err);
-//                     // error!("Client seems disconnected, closing resources");
-//                     // if let Err(_) = close_sender_clone.send(()) {
-//                     //     error!("Failed to close all client streams & resources")
-//                     // }
-//                     to_sync_client.send(
-//                         InternalAsyncMessage::LostConnection)
-//                         .await
-//                         .expect("Failed to signal connection lost to sync client");
-//                 }
-//             }
-//         } => {
-//             trace!("Unordered Reliable Send Channel ended")
-//         }
+//     if let Err(err) = frame_send.send(msg_bytes).await {
+//         error!("Error while sending, {}", err);
+//         error!("Client seems disconnected, closing resources");
+//         // Emit LostConnection to properly update the connection about its state.
+//         // Raise LostConnection event before emitting a close signal because we have no guarantee to continue this async execution after the close signal has been processed.
+//         to_sync_client
+//             .send(InternalAsyncMessage::LostConnection)
+//             .await
+//             .expect("Failed to signal connection lost to sync client");
+//         // if let Err(_) = close_sender.send(()) {
+//         //     error!("Failed to close all client streams & resources")
+//         // }
 //     }
 // }

--- a/src/shared/channel.rs
+++ b/src/shared/channel.rs
@@ -14,20 +14,29 @@ pub(crate) type MultiChannelId = u64;
 
 #[derive(Debug, Copy, Clone)]
 pub enum ChannelType {
-    OrderedReliable,
-    UnorderedReliable,
-    Unreliable,
-}
-
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub enum ChannelId {
     /// An OrderedReliable channel ensures that messages sent are delivered, and are processed by the receiving end in the same order as they were sent.
-    OrderedReliable(MultiChannelId),
+    OrderedReliable,
     /// An UnorderedReliable channel ensures that messages sent are delivered, but they may be delivered out of order.
     UnorderedReliable,
     /// Channel which transmits messages as unreliable and unordered datagrams (may be lost or delivered out of order).
     ///
     /// The maximum allowed size of a datagram may change over the lifetime of a connection according to variation in the path MTU estimate. This is guaranteed to be a little over a kilobyte at minimum.
+    Unreliable,
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum ChannelId {
+    /// There may be more than one OrderedReliable channel instance. This may be useful to avoid some Head of line blocking (<https://en.wikipedia.org/wiki/Head-of-line_blocking>) issues.
+    ///
+    /// See [ChannelType::OrderedReliable] for more information.
+    OrderedReliable(MultiChannelId),
+    /// One `UnorderedReliable` channel instance is enough since messages are not ordered on those, in fact even if you tried to create more, Quinnet would just reuse the existing one. This is why you can directly use this [ChannelId::UnorderedReliable] when sending messages.
+    ///
+    /// See [ChannelType::UnorderedReliable] for more information.
+    UnorderedReliable,
+    /// One `Unreliable` channel instance is enough since messages are not ordered on those, in fact even if you tried to create more, Quinnet would just reuse the existing one. This is why you can directly use this [ChannelId::Unreliable] when sending messages.
+    ///
+    /// See [ChannelType::Unreliable] for more information.
     Unreliable,
 }
 

--- a/src/shared/channel.rs
+++ b/src/shared/channel.rs
@@ -81,6 +81,20 @@ impl Channel {
     }
 }
 
+pub(crate) fn get_channel_id_from_type<F>(
+    channel_type: ChannelType,
+    mut multi_id_generator: F,
+) -> ChannelId
+where
+    F: FnMut() -> MultiChannelId,
+{
+    match channel_type {
+        ChannelType::OrderedReliable => ChannelId::OrderedReliable(multi_id_generator()),
+        ChannelType::UnorderedReliable => ChannelId::UnorderedReliable,
+        ChannelType::Unreliable => ChannelId::Unreliable,
+    }
+}
+
 pub(crate) async fn ordered_reliable_channel_task(
     connection: quinn::Connection,
     _: mpsc::Sender<()>,

--- a/src/shared/channel.rs
+++ b/src/shared/channel.rs
@@ -10,7 +10,7 @@ use tokio::sync::{
 };
 use tokio_util::codec::{FramedWrite, LengthDelimitedCodec};
 
-pub(crate) type OrdRelChannelId = u64;
+pub(crate) type MultiChannelId = u64;
 
 #[derive(Debug, Copy, Clone)]
 pub enum ChannelType {
@@ -21,7 +21,7 @@ pub enum ChannelType {
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum ChannelId {
-    OrderedReliable(OrdRelChannelId),
+    OrderedReliable(MultiChannelId),
     UnorderedReliable,
     Unreliable,
 }
@@ -132,24 +132,3 @@ async fn new_uni_frame_sender(
         .expect("Failed to open send stream");
     FramedWrite::new(uni_sender, LengthDelimitedCodec::new())
 }
-
-// async fn send_msg(
-//     // close_sender: &tokio::sync::broadcast::Sender<()>,
-//     to_sync_client: &mpsc::Sender<InternalAsyncMessage>,
-//     frame_send: &mut FramedWrite<SendStream, LengthDelimitedCodec>,
-//     msg_bytes: Bytes,
-// ) {
-//     if let Err(err) = frame_send.send(msg_bytes).await {
-//         error!("Error while sending, {}", err);
-//         error!("Client seems disconnected, closing resources");
-//         // Emit LostConnection to properly update the connection about its state.
-//         // Raise LostConnection event before emitting a close signal because we have no guarantee to continue this async execution after the close signal has been processed.
-//         to_sync_client
-//             .send(InternalAsyncMessage::LostConnection)
-//             .await
-//             .expect("Failed to signal connection lost to sync client");
-//         // if let Err(_) = close_sender.send(()) {
-//         //     error!("Failed to close all client streams & resources")
-//         // }
-//     }
-// }

--- a/src/shared/channel.rs
+++ b/src/shared/channel.rs
@@ -47,7 +47,7 @@ pub(crate) enum ChannelSyncMessage {
 }
 
 #[derive(Debug)]
-pub struct Channel {
+pub(crate) struct Channel {
     sender: mpsc::Sender<Bytes>,
     close_sender: mpsc::Sender<()>,
 }
@@ -145,7 +145,9 @@ pub(crate) async fn channels_task(
                             .await
                         });
                     },
-                    ChannelId::Unreliable => todo!(),
+                    ChannelId::Unreliable => {
+                        // TODO
+                    },
                 }
             }
         } => {

--- a/src/shared/channel.rs
+++ b/src/shared/channel.rs
@@ -12,12 +12,12 @@ use super::QuinnetError;
 
 pub(crate) type OrdRelChannelId = u64;
 
-// #[derive(Debug, Copy, Clone)]
-// pub enum ChannelType {
-//     OrderedReliable,
-//     UnorderedReliable,
-//     Unreliable,
-// }
+#[derive(Debug, Copy, Clone)]
+pub enum ChannelType {
+    OrderedReliable,
+    UnorderedReliable,
+    Unreliable,
+}
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum ChannelId {

--- a/src/shared/channel.rs
+++ b/src/shared/channel.rs
@@ -43,7 +43,7 @@ impl Channel {
             Ok(_) => Ok(()),
             Err(err) => match err {
                 TrySendError::Full(_) => Err(QuinnetError::FullQueue),
-                TrySendError::Closed(_) => Err(QuinnetError::ChannelClosed),
+                TrySendError::Closed(_) => Err(QuinnetError::InternalChannelClosed),
             },
         }
     }

--- a/src/shared/channel.rs
+++ b/src/shared/channel.rs
@@ -1,0 +1,128 @@
+use bevy::prelude::{error, trace};
+use bytes::Bytes;
+use futures::sink::SinkExt;
+use futures_util::StreamExt;
+use tokio::sync::{
+    broadcast,
+    mpsc::{self, error::TrySendError},
+};
+use tokio_util::codec::{FramedRead, FramedWrite, LengthDelimitedCodec};
+
+use super::QuinnetError;
+
+pub(crate) type OrdRelChannelId = u64;
+
+// #[derive(Debug, Copy, Clone)]
+// pub enum ChannelType {
+//     OrderedReliable,
+//     UnorderedReliable,
+//     Unreliable,
+// }
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum ChannelId {
+    OrderedReliable(OrdRelChannelId),
+    UnorderedReliable,
+    Unreliable,
+}
+
+impl std::fmt::Display for ChannelId {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+#[derive(Debug)]
+pub struct Channel {
+    sender: mpsc::Sender<Bytes>,
+}
+
+impl Channel {
+    pub fn send_payload<T: Into<Bytes>>(&self, payload: T) -> Result<(), QuinnetError> {
+        match self.sender.try_send(payload.into()) {
+            Ok(_) => Ok(()),
+            Err(err) => match err {
+                TrySendError::Full(_) => Err(QuinnetError::FullQueue),
+                TrySendError::Closed(_) => Err(QuinnetError::ChannelClosed),
+            },
+        }
+    }
+
+    pub(crate) fn new(sender: mpsc::Sender<Bytes>) -> Self {
+        Self { sender }
+    }
+}
+
+// async fn ordered_reliable_channel_task(
+//     connection: quinn::Connection,
+//     to_sync_client: mpsc::Sender<InternalAsyncMessage>,
+//     mut close_receiver: broadcast::Receiver<()>,
+//     mut to_server_receiver: mpsc::Receiver<Bytes>,
+// ) {
+//     tokio::select! {
+//         _ = close_receiver.recv() => {
+//             trace!("Ordered Reliable Send Channel received a close signal")
+//         }
+//         _ = async {
+//             let uni_sender = connection
+//                 .open_uni()
+//                 .await
+//                 .expect("Failed to open send stream");
+//             let mut frame_sender = FramedWrite::new(uni_sender, LengthDelimitedCodec::new());
+
+//             while let Some(msg_bytes) = to_server_receiver.recv().await {
+//                 if let Err(err) = frame_sender.send(msg_bytes).await {
+//                     // TODO Clean: error handling
+//                     error!("Error while sending, {}", err);
+//                     // error!("Client seems disconnected, closing resources");
+//                     // if let Err(_) = close_sender_clone.send(()) {
+//                     //     error!("Failed to close all client streams & resources")
+//                     // }
+//                     to_sync_client.send(
+//                         InternalAsyncMessage::LostConnection)
+//                         .await
+//                         .expect("Failed to signal connection lost to sync client");
+//                 }
+//             }
+//         } => {
+//             trace!("Ordered Reliable Send Channel ended")
+//         }
+//     }
+// }
+
+// async fn unordered_reliable_channel_task(
+//     connection: quinn::Connection,
+//     to_sync_client: mpsc::Sender<InternalAsyncMessage>,
+//     mut close_receiver: broadcast::Receiver<()>,
+//     mut to_server_receiver: mpsc::Receiver<Bytes>,
+// ) {
+//     tokio::select! {
+//         _ = close_receiver.recv() => {
+//             trace!("Unordered Reliable Send Channel received a close signal")
+//         }
+//         _ = async {
+//             while let Some(msg_bytes) = to_server_receiver.recv().await {
+//                 let uni_sender = connection
+//                     .open_uni()
+//                     .await
+//                     .expect("Failed to open send stream");
+//                 let mut frame_sender = FramedWrite::new(uni_sender, LengthDelimitedCodec::new());
+
+//                 if let Err(err) = frame_sender.send(msg_bytes).await {
+//                     // TODO Clean: error handling
+//                     error!("Error while sending, {}", err);
+//                     // error!("Client seems disconnected, closing resources");
+//                     // if let Err(_) = close_sender_clone.send(()) {
+//                     //     error!("Failed to close all client streams & resources")
+//                     // }
+//                     to_sync_client.send(
+//                         InternalAsyncMessage::LostConnection)
+//                         .await
+//                         .expect("Failed to signal connection lost to sync client");
+//                 }
+//             }
+//         } => {
+//             trace!("Unordered Reliable Send Channel ended")
+//         }
+//     }
+// }


### PR DESCRIPTION
### Add send channels to Quinnet:

- Changes:
  - `OrderedReliable` 
  - `UnorderedReliable` 
  - `Unreliable`
  - Add 2 new important API calls on server & client: `open_channel `and `close_channel` (and a few minor utilities such as some `try_` functions)
  - Add new error types and rename ambiguous `ChannelClosed` to `InternalChannelClosed`

- Task list:
  - [x] Channels on the client
  - [x] Channels on the server
  - [x] Default channels creation
  - [x] Keep the current simple API working by default
  - [x] Open & close channels at runtime
  - [x] Graceful shutdown, wait for all channels to be properly flushed and finished
  - [x] Share channels implementation
  - [x] Documentation

- Implement channel types:
  - [x] OrderedReliable 
  - [x] UnorderedReliable 
  - [x] Unreliable 


