### PR TITLE
[client & server] Fix IPv6 handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Version 0.4.0-dev
+
+- [client]: Fix IPv6 handling.
+  - Remove `ConnectionConfiguration::new`
+  - Add `ConnectionConfiguration::from_strings`, `ConnectionConfiguration::from_ips` and `ConnectionConfiguration::from_addrs`
+- [server]: Fix IPv6 handling.
+  - Rename `ServerConfigurationData` to `ServerConfiguration`.
+  - Remove `ServerConfiguration::new`
+  - Add `ServerConfiguration::from_string`, `ServerConfiguration::from_ip` and `ServerConfiguration::from_addr`
+  - Add `server_hostname` to `CertificateRetrievalMode::GenerateSelfSigned` and `CertificateRetrievalMode::LoadFromFileOrGenerateSelfSigned`
+
 ## Version 0.3.0 (2023-01-20)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -95,10 +95,10 @@ This is a bird-eye view of the features/tasks that will probably be worked on ne
 fn start_connection(client: ResMut<Client>) {
     client
         .open_connection(
-            ClientConfigurationData::new(
-                "127.0.0.1".to_string(),
+            ClientConfigurationData::from_ips(
+                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
                 6000,
-                "0.0.0.0".to_string(),
+                IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
                 0,
             ),
             CertificateVerificationMode::SkipVerification,
@@ -143,7 +143,7 @@ fn handle_server_messages(
 fn start_listening(mut server: ResMut<Server>) {
     server
         .start_endpoint(
-            ServerConfigurationData::new("127.0.0.1".to_string(), 6000, "0.0.0.0".to_string()),
+            ServerConfigurationData::from_ip(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 6000),
             CertificateRetrievalMode::GenerateSelfSigned,
         )
         .unwrap();
@@ -258,7 +258,9 @@ On the server:
 
 ```rust
     // To generate a new self-signed certificate on each startup 
-    server.start_endpoint(/*...*/, CertificateRetrievalMode::GenerateSelfSigned);
+    server.start_endpoint(/*...*/, CertificateRetrievalMode::GenerateSelfSigned { 
+        server_hostname: "127.0.0.1".to_string(),
+    });
     // To load a pre-existing one from files
     server.start_endpoint(/*...*/, CertificateRetrievalMode::LoadFromFile {
         cert_file: "./certificates.pem".into(),
@@ -269,6 +271,7 @@ On the server:
         cert_file: "./certificates.pem".into(),
         key_file: "./privkey.pem".into(),
         save_on_disk: true, // To persist on disk if generated
+        server_hostname: "127.0.0.1".to_string(),
     });
 ```
 

--- a/examples/breakout/breakout.rs
+++ b/examples/breakout/breakout.rs
@@ -1,6 +1,8 @@
 //! A simplified implementation of the classic game "Breakout".
 //! => Original example by Bevy, modified for Bevy Quinnet to add a 2 players versus mode.
 
+use std::net::{IpAddr, Ipv4Addr};
+
 use bevy::{ecs::schedule::ShouldRun, prelude::*, time::FixedTimestep};
 use bevy_quinnet::{
     client::QuinnetClientPlugin,
@@ -13,6 +15,7 @@ mod protocol;
 mod server;
 
 const SERVER_HOST: &str = "127.0.0.1";
+const LOCAL_BIND_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0));
 const SERVER_PORT: u16 = 6000;
 
 // Defines the amount of time that should elapse between each physics step.

--- a/examples/breakout/client.rs
+++ b/examples/breakout/client.rs
@@ -24,7 +24,8 @@ use bevy_quinnet::{
 use crate::{
     protocol::{ClientMessage, PaddleInput, ServerMessage},
     BrickId, CollisionEvent, CollisionSound, GameState, Score, Velocity, WallLocation, BALL_SIZE,
-    BALL_SPEED, BRICK_SIZE, GAP_BETWEEN_BRICKS, PADDLE_SIZE, SERVER_HOST, SERVER_PORT, TIME_STEP,
+    BALL_SPEED, BRICK_SIZE, GAP_BETWEEN_BRICKS, LOCAL_BIND_IP, PADDLE_SIZE, SERVER_HOST,
+    SERVER_PORT, TIME_STEP,
 };
 
 const SCOREBOARD_FONT_SIZE: f32 = 40.0;
@@ -91,14 +92,13 @@ struct WallBundle {
     #[bundle]
     sprite_bundle: SpriteBundle,
 }
-
 pub(crate) fn start_connection(mut client: ResMut<Client>) {
     client
         .open_connection(
-            ConnectionConfiguration::new(
-                SERVER_HOST.to_string(),
+            ConnectionConfiguration::from_ips(
+                SERVER_HOST.parse().unwrap(),
                 SERVER_PORT,
-                "0.0.0.0".to_string(),
+                LOCAL_BIND_IP,
                 0,
             ),
             CertificateVerificationMode::SkipVerification,

--- a/examples/breakout/server.rs
+++ b/examples/breakout/server.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap};
 
 use bevy::{
     prelude::{
@@ -9,9 +9,7 @@ use bevy::{
     transform::TransformBundle,
 };
 use bevy_quinnet::{
-    server::{
-        certificate::CertificateRetrievalMode, ConnectionEvent, Server, ServerConfigurationData,
-    },
+    server::{certificate::CertificateRetrievalMode, ConnectionEvent, Server, ServerConfiguration},
     shared::{channel::ChannelId, ClientId},
 };
 
@@ -19,8 +17,8 @@ use crate::{
     protocol::{ClientMessage, PaddleInput, ServerMessage},
     BrickId, Velocity, WallLocation, BALL_SIZE, BALL_SPEED, BOTTOM_WALL, BRICK_SIZE,
     GAP_BETWEEN_BRICKS, GAP_BETWEEN_BRICKS_AND_SIDES, GAP_BETWEEN_PADDLE_AND_BRICKS,
-    GAP_BETWEEN_PADDLE_AND_FLOOR, LEFT_WALL, PADDLE_PADDING, PADDLE_SIZE, PADDLE_SPEED, RIGHT_WALL,
-    SERVER_HOST, SERVER_PORT, TIME_STEP, TOP_WALL, WALL_THICKNESS,
+    GAP_BETWEEN_PADDLE_AND_FLOOR, LEFT_WALL, LOCAL_BIND_IP, PADDLE_PADDING, PADDLE_SIZE,
+    PADDLE_SPEED, RIGHT_WALL, SERVER_HOST, SERVER_PORT, TIME_STEP, TOP_WALL, WALL_THICKNESS,
 };
 
 const GAP_BETWEEN_PADDLE_AND_BALL: f32 = 35.;
@@ -81,12 +79,10 @@ struct WallBundle {
 pub(crate) fn start_listening(mut server: ResMut<Server>) {
     server
         .start_endpoint(
-            ServerConfigurationData::new(
-                SERVER_HOST.to_string(),
-                SERVER_PORT,
-                "0.0.0.0".to_string(),
-            ),
-            CertificateRetrievalMode::GenerateSelfSigned,
+            ServerConfiguration::from_ip(LOCAL_BIND_IP, SERVER_PORT),
+            CertificateRetrievalMode::GenerateSelfSigned {
+                server_hostname: SERVER_HOST.to_string(),
+            },
         )
         .unwrap();
 }

--- a/examples/chat/client.rs
+++ b/examples/chat/client.rs
@@ -120,7 +120,7 @@ fn start_terminal_listener(mut commands: Commands) {
 fn start_connection(mut client: ResMut<Client>) {
     client
         .open_connection(
-            ConnectionConfiguration::new("127.0.0.1".to_string(), 6000, "0.0.0.0".to_string(), 0),
+            ConnectionConfiguration::from_strings("127.0.0.1:6000", "0.0.0.0:0").unwrap(),
             CertificateVerificationMode::SkipVerification,
         )
         .unwrap();

--- a/examples/chat/server.rs
+++ b/examples/chat/server.rs
@@ -4,7 +4,7 @@ use bevy::{app::ScheduleRunnerPlugin, log::LogPlugin, prelude::*};
 use bevy_quinnet::{
     server::{
         certificate::CertificateRetrievalMode, ConnectionLostEvent, Endpoint, QuinnetServerPlugin,
-        Server, ServerConfigurationData,
+        Server, ServerConfiguration,
     },
     shared::{channel::ChannelId, ClientId},
 };
@@ -116,8 +116,10 @@ fn handle_disconnect(endpoint: &mut Endpoint, users: &mut ResMut<Users>, client_
 fn start_listening(mut server: ResMut<Server>) {
     server
         .start_endpoint(
-            ServerConfigurationData::new("127.0.0.1".to_string(), 6000, "0.0.0.0".to_string()),
-            CertificateRetrievalMode::GenerateSelfSigned,
+            ServerConfiguration::from_string("0.0.0.0:6000").unwrap(),
+            CertificateRetrievalMode::GenerateSelfSigned {
+                server_hostname: "127.0.0.1".to_string(),
+            },
         )
         .unwrap();
 }

--- a/tests/certificates.rs
+++ b/tests/certificates.rs
@@ -8,7 +8,7 @@ use bevy_quinnet::{
         Client, QuinnetClientPlugin, DEFAULT_KNOWN_HOSTS_FILE,
     },
     server::{
-        certificate::CertificateRetrievalMode, QuinnetServerPlugin, Server, ServerConfigurationData,
+        certificate::CertificateRetrievalMode, QuinnetServerPlugin, Server, ServerConfiguration,
     },
 };
 
@@ -72,7 +72,7 @@ fn trust_on_first_use() {
         let mut server = server_app.world.resource_mut::<Server>();
         let (server_cert, _) = server
             .start_endpoint(
-                ServerConfigurationData::new(SERVER_HOST.to_string(), port, "0.0.0.0".to_string()),
+                ServerConfiguration::from_ip("0.0.0.0".parse().unwrap(), port),
                 CertificateRetrievalMode::LoadFromFile {
                     cert_file: TEST_CERT_FILE.to_string(),
                     key_file: TEST_KEY_FILE.to_string(),
@@ -130,7 +130,7 @@ fn trust_on_first_use() {
         );
         assert_eq!(
             cert_info.server_name.to_string(),
-            SERVER_HOST.to_string(),
+            SERVER_IP.to_string(),
             "The server name should match the one we configured"
         );
 
@@ -200,8 +200,10 @@ fn trust_on_first_use() {
         .world
         .resource_mut::<Server>()
         .start_endpoint(
-            ServerConfigurationData::new(SERVER_HOST.to_string(), port, "0.0.0.0".to_string()),
-            CertificateRetrievalMode::GenerateSelfSigned,
+            ServerConfiguration::from_ip(LOCAL_BIND_IP, port),
+            CertificateRetrievalMode::GenerateSelfSigned {
+                server_hostname: SERVER_IP.to_string(),
+            },
         )
         .unwrap();
 
@@ -270,7 +272,7 @@ fn trust_on_first_use() {
         );
         assert_eq!(
             interaction_cert_info.server_name.to_string(),
-            SERVER_HOST.to_string(),
+            SERVER_IP.to_string(),
             "The server name in the certificate interaction event should be the server we want to connect to"
         );
         assert_eq!(


### PR DESCRIPTION
Fixes #9 

Changelog extract:

- [client]: Fix IPv6 handling.
  - Remove `ConnectionConfiguration::new`
  - Add `ConnectionConfiguration::from_strings`, `ConnectionConfiguration::from_ips` and `ConnectionConfiguration::from_addrs`
- [server]: Fix IPv6 handling.
  - Rename `ServerConfigurationData` to `ServerConfiguration`.
  - Remove `ServerConfiguration::new`
  - Add `ServerConfiguration::from_string`, `ServerConfiguration::from_ip` and `ServerConfiguration::from_addr`
  - Add `server_hostname` to `CertificateRetrievalMode::GenerateSelfSigned` and `CertificateRetrievalMode::LoadFromFileOrGenerateSelfSigned`
