### PR TITLE
changed all docs, examples and tests to current internet protocol version

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ fn start_connection(client: ResMut<QuinnetClient>) {
     client
         .open_connection(
             ClientEndpointConfiguration::from_ips(
-                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+                IpAddr::V4(Ipv6Addr::new('::1')),
                 6000,
-                IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+                IpAddr::V4(Ipv6Addr::new('::')),
                 0,
             ),
             CertificateVerificationMode::SkipVerification,
@@ -147,7 +147,7 @@ fn handle_server_messages(
 fn start_listening(mut server: ResMut<QuinnetServer>) {
     server
         .start_endpoint(
-            ServerEndpointConfiguration::from_ip(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 6000),
+            ServerEndpointConfiguration::from_ip(IpAddr::V4(Ipv6Addr::new('::')), 6000),
             CertificateRetrievalMode::GenerateSelfSigned,
             ChannelsConfiguration::default(),
         )
@@ -276,7 +276,7 @@ On the server:
 ```rust
     // To generate a new self-signed certificate on each startup 
     server.start_endpoint(/*...*/, CertificateRetrievalMode::GenerateSelfSigned { 
-        server_hostname: "127.0.0.1".to_string(),
+        server_hostname: "::1".to_string(),
     });
     // To load a pre-existing one from files
     server.start_endpoint(/*...*/, CertificateRetrievalMode::LoadFromFile {
@@ -288,7 +288,7 @@ On the server:
         cert_file: "./certificates.pem".into(),
         key_file: "./privkey.pem".into(),
         save_on_disk: true, // To persist on disk if generated
-        server_hostname: "127.0.0.1".to_string(),
+        server_hostname: "::1".to_string(),
     });
 ```
 

--- a/bevy_replicon_quinnet/examples/simple_box.rs
+++ b/bevy_replicon_quinnet/examples/simple_box.rs
@@ -3,7 +3,7 @@
 
 use std::{
     error::Error,
-    net::{IpAddr, Ipv4Addr},
+    net::{IpAddr, Ipv6Addr},
 };
 
 use bevy::{
@@ -84,9 +84,9 @@ impl SimpleBoxPlugin {
             Cli::Server { port } => {
                 server
                     .start_endpoint(
-                        ServerEndpointConfiguration::from_ip(IpAddr::V4(Ipv4Addr::LOCALHOST), port),
+                        ServerEndpointConfiguration::from_ip(IpAddr::V6(Ipv6Addr::LOCALHOST), port),
                         CertificateRetrievalMode::GenerateSelfSigned {
-                            server_hostname: Ipv4Addr::LOCALHOST.to_string(),
+                            server_hostname: Ipv6Addr::LOCALHOST.to_string(),
                         },
                         channels.get_server_configs(),
                     )
@@ -112,7 +112,7 @@ impl SimpleBoxPlugin {
                         ClientEndpointConfiguration::from_ips(
                             ip,
                             port,
-                            IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+                            IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)),
                             0,
                         ),
                         CertificateVerificationMode::SkipVerification,
@@ -221,7 +221,7 @@ enum Cli {
         port: u16,
     },
     Client {
-        #[arg(short, long, default_value_t = Ipv4Addr::LOCALHOST.into())]
+        #[arg(short, long, default_value_t = Ipv6Addr::LOCALHOST.into())]
         ip: IpAddr,
 
         #[arg(short, long, default_value_t = PORT)]

--- a/bevy_replicon_quinnet/examples/tic_tac_toe.rs
+++ b/bevy_replicon_quinnet/examples/tic_tac_toe.rs
@@ -4,7 +4,7 @@
 use std::{
     error::Error,
     fmt::{self, Formatter},
-    net::{IpAddr, Ipv4Addr},
+    net::{IpAddr, Ipv6Addr},
 };
 
 use bevy::prelude::*;
@@ -251,9 +251,9 @@ impl TicTacToePlugin {
             Cli::Server { port, symbol } => {
                 server
                     .start_endpoint(
-                        ServerEndpointConfiguration::from_ip(IpAddr::V4(Ipv4Addr::LOCALHOST), port),
+                        ServerEndpointConfiguration::from_ip(IpAddr::V6(Ipv6Addr::LOCALHOST), port),
                         CertificateRetrievalMode::GenerateSelfSigned {
-                            server_hostname: Ipv4Addr::LOCALHOST.to_string(),
+                            server_hostname: Ipv6Addr::LOCALHOST.to_string(),
                         },
                         channels.get_server_configs(),
                     )
@@ -266,7 +266,7 @@ impl TicTacToePlugin {
                         ClientEndpointConfiguration::from_ips(
                             ip,
                             port,
-                            IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+                            IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)),
                             0,
                         ),
                         CertificateVerificationMode::SkipVerification,
@@ -515,7 +515,7 @@ enum Cli {
         symbol: Symbol,
     },
     Client {
-        #[arg(short, long, default_value_t = Ipv4Addr::LOCALHOST.into())]
+        #[arg(short, long, default_value_t = Ipv6Addr::LOCALHOST.into())]
         ip: IpAddr,
 
         #[arg(short, long, default_value_t = PORT)]

--- a/bevy_replicon_quinnet/tests/transport.rs
+++ b/bevy_replicon_quinnet/tests/transport.rs
@@ -1,5 +1,5 @@
 use std::{
-    net::{IpAddr, Ipv4Addr},
+    net::{IpAddr, Ipv6Addr},
     thread::sleep,
     time::Duration,
 };
@@ -155,9 +155,9 @@ fn setup_client(app: &mut App, server_port: u16) {
     client
         .open_connection(
             ClientEndpointConfiguration::from_ips(
-                IpAddr::V4(Ipv4Addr::LOCALHOST),
+                IpAddr::V6(Ipv6Addr::LOCALHOST),
                 server_port,
-                IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+                IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)),
                 0,
             ),
             CertificateVerificationMode::SkipVerification,
@@ -175,9 +175,9 @@ fn setup_server(app: &mut App, server_port: u16) {
     let mut server = app.world_mut().resource_mut::<QuinnetServer>();
     server
         .start_endpoint(
-            ServerEndpointConfiguration::from_ip(IpAddr::V4(Ipv4Addr::LOCALHOST), server_port),
+            ServerEndpointConfiguration::from_ip(IpAddr::V6(Ipv6Addr::LOCALHOST), server_port),
             CertificateRetrievalMode::GenerateSelfSigned {
-                server_hostname: Ipv4Addr::LOCALHOST.to_string(),
+                server_hostname: Ipv6Addr::LOCALHOST.to_string(),
             },
             channels_config,
         )

--- a/docs/Certificates.md
+++ b/docs/Certificates.md
@@ -90,8 +90,8 @@ There is one line per entry, and each entry is a server name (as dns or ip) foll
 
 Example:
 ```
-127.0.0.1 o1cpTe602uTq4pVwT+km8QtEPQE/xCAgk+3AicW/i9g=
-123.123.123.123 kzXIwhvMSbWCQOimT3btnFlmc/Lq0UN0JhSeQadaGbg=
+::1 o1cpTe602uTq4pVwT+km8QtEPQE/xCAgk+3AicW/i9g=
+1234::1234 kzXIwhvMSbWCQOimT3btnFlmc/Lq0UN0JhSeQadaGbg=
 ```
 
 #### Limitations 

--- a/examples/breakout/breakout.rs
+++ b/examples/breakout/breakout.rs
@@ -1,7 +1,7 @@
 //! A simplified implementation of the classic game "Breakout".
 //! => Original example by Bevy, modified for Bevy Quinnet to add a 2 players versus mode.
 
-use std::net::{IpAddr, Ipv4Addr};
+use std::net::{IpAddr, Ipv6Addr};
 
 use bevy::prelude::*;
 use bevy_quinnet::{
@@ -14,8 +14,8 @@ mod client;
 mod protocol;
 mod server;
 
-const SERVER_HOST: &str = "127.0.0.1";
-const LOCAL_BIND_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0));
+const SERVER_HOST: &str = "::1";
+const LOCAL_BIND_IP: IpAddr = IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0));
 const SERVER_PORT: u16 = 6000;
 
 // Defines the amount of time that should elapse between each physics step.

--- a/examples/chat/client.rs
+++ b/examples/chat/client.rs
@@ -123,7 +123,7 @@ fn start_terminal_listener(mut commands: Commands) {
 fn start_connection(mut client: ResMut<QuinnetClient>) {
     client
         .open_connection(
-            ClientEndpointConfiguration::from_strings("127.0.0.1:6000", "0.0.0.0:0").unwrap(),
+            ClientEndpointConfiguration::from_strings("[::1]:6000", "[::]:0").unwrap(),
             CertificateVerificationMode::SkipVerification,
             ChannelsConfiguration::default(),
         )

--- a/examples/chat/server.rs
+++ b/examples/chat/server.rs
@@ -116,9 +116,9 @@ fn handle_disconnect(endpoint: &mut Endpoint, users: &mut ResMut<Users>, client_
 fn start_listening(mut server: ResMut<QuinnetServer>) {
     server
         .start_endpoint(
-            ServerEndpointConfiguration::from_string("0.0.0.0:6000").unwrap(),
+            ServerEndpointConfiguration::from_string("[::]:6000").unwrap(),
             CertificateRetrievalMode::GenerateSelfSigned {
-                server_hostname: "127.0.0.1".to_string(),
+                server_hostname: "::1".to_string(),
             },
             ChannelsConfiguration::default(),
         )

--- a/tests/certificates.rs
+++ b/tests/certificates.rs
@@ -81,7 +81,7 @@ fn trust_on_first_use() {
         let mut server = server_app.world_mut().resource_mut::<QuinnetServer>();
         let server_cert = server
             .start_endpoint(
-                ServerEndpointConfiguration::from_ip("0.0.0.0".parse().unwrap(), port),
+                ServerEndpointConfiguration::from_ip("::".parse().unwrap(), port),
                 CertificateRetrievalMode::LoadFromFile {
                     cert_file: TEST_CERT_FILE.to_string(),
                     key_file: TEST_KEY_FILE.to_string(),

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -1,5 +1,5 @@
 use std::{
-    net::{IpAddr, Ipv4Addr},
+    net::{IpAddr, Ipv6Addr},
     thread::sleep,
     time::Duration,
 };
@@ -62,8 +62,8 @@ pub enum SharedMessage {
     TestMessage(String),
 }
 
-pub const SERVER_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-pub const LOCAL_BIND_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0));
+pub const SERVER_IP: IpAddr = IpAddr::V6(Ipv6Addr::new(0 ,0, 0, 0, 0, 0, 0, 1));
+pub const LOCAL_BIND_IP: IpAddr = IpAddr::V6(Ipv6Addr::new(0 ,0, 0, 0, 0, 0, 0, 0));
 
 pub fn build_client_app() -> App {
     let mut client_app = App::new();


### PR DESCRIPTION
Since 2017, Internet Protocol version 6 (IPv6) has been the standard. I believe it's time we all adopt it. Currently, 40% of the world is already using IPv6, and it would help many people who rely solely on this protocol.

IPv6 offers numerous advantages over its predecessor, IPv4. It provides a significantly larger address space, which is crucial as the number of internet-connected devices continues to grow exponentially. This ensures that we won't run out of IP addresses, allowing for the continued expansion of the internet.

Furthermore, IPv6 enhances security features with mandatory support for IPsec, which can help protect data transmitted over the internet. It also simplifies network configuration through auto-configuration capabilities, reducing the need for manual setup and maintenance.

By transitioning to IPv6, we can improve the efficiency and security of our networks, support the increasing number of devices, and ensure a future-proof internet infrastructure. It's a change that benefits everyone, from individual users to large organizations.