### PR TITLE
add derives to client events to match server events

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -40,7 +40,7 @@ pub mod connection;
 pub const DEFAULT_KNOWN_HOSTS_FILE: &str = "quinnet/known_hosts";
 
 /// Possible errors occuring while a client is connecting to a server
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, Clone)]
 pub enum QuinnetConnectionError {
     /// A quic error occurred during the connection
     #[error("Quic connection error")]

--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -52,7 +52,7 @@ use super::{
 pub type ConnectionLocalId = u64;
 
 /// Connection event raised when the client just connected to the server. Raised in the CoreStage::PreUpdate stage.
-#[derive(Event)]
+#[derive(Event, Debug, Copy, Clone)]
 pub struct ConnectionEvent {
     /// Local id of the connection
     pub id: ConnectionLocalId,
@@ -63,7 +63,7 @@ pub struct ConnectionEvent {
 }
 
 /// Connection event raised when the client failed to connect to the server. Raised in the CoreStage::PreUpdate stage.
-#[derive(Event)]
+#[derive(Event, Debug, Clone)]
 pub struct ConnectionFailedEvent {
     /// Local id of the connection which failed to connect
     pub id: ConnectionLocalId,
@@ -72,7 +72,7 @@ pub struct ConnectionFailedEvent {
 }
 
 /// ConnectionLost event raised when the client is considered disconnected from the server. Raised in the CoreStage::PreUpdate stage.
-#[derive(Event)]
+#[derive(Event, Debug, Copy, Clone)]
 pub struct ConnectionLostEvent {
     /// Local id of the connection
     pub id: ConnectionLocalId,


### PR DESCRIPTION
add derives to client events to match server events as far as possible

Tried to debug print client event.
Didn't work :)

Thx for this crate btw.