### PR TITLE
Rework error handling in the sync API

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -267,7 +267,7 @@ impl QuinnetClient {
     pub fn close_connection(
         &mut self,
         connection_id: ConnectionLocalId,
-    ) -> Result<(), ConnectionCloseError> {
+    ) -> Result<(), ClientConnectionCloseError> {
         match self.connections.remove(&connection_id) {
             Some(mut connection) => {
                 if Some(connection_id) == self.default_connection_id {
@@ -275,7 +275,9 @@ impl QuinnetClient {
                 }
                 connection.disconnect()
             }
-            None => Err(ConnectionCloseError::InvalidConnectionId(connection_id)),
+            None => Err(ClientConnectionCloseError::InvalidConnectionId(
+                connection_id,
+            )),
         }
     }
 

--- a/src/client/certificate.rs
+++ b/src/client/certificate.rs
@@ -193,7 +193,7 @@ pub enum KnownHosts {
     /// Directly contains the server name to fingerprint mapping
     Store(CertStore),
     /// Path of a file caontaing the server name to fingerprint mapping.
-    HostsFile(String), // TODO More on the file format + the limitations
+    HostsFile(String),
 }
 
 /// Implementation of `ServerCertVerifier` that verifies everything as trustworthy.

--- a/src/client/certificate.rs
+++ b/src/client/certificate.rs
@@ -13,9 +13,12 @@ use futures::executor::block_on;
 use rustls::pki_types::{CertificateDer, ServerName as RustlsServerName, UnixTime};
 use tokio::sync::{mpsc, oneshot};
 
-use crate::shared::{certificate::CertificateFingerprint, error::QuinnetError};
+use crate::shared::{certificate::CertificateFingerprint, error::AsyncChannelError};
 
-use super::{ClientAsyncMessage, ConnectionLocalId, DEFAULT_KNOWN_HOSTS_FILE};
+use super::{
+    CertificateInteractionError, ClientAsyncMessage, ConnectionLocalId, InvalidHostFile,
+    DEFAULT_KNOWN_HOSTS_FILE,
+};
 
 /// Default certificate behavior is to abort the connection
 pub const DEFAULT_CERT_VERIFIER_BEHAVIOUR: CertVerifierBehaviour =
@@ -39,15 +42,15 @@ impl CertInteractionEvent {
     pub fn apply_cert_verifier_action(
         &self,
         action: CertVerifierAction,
-    ) -> Result<(), QuinnetError> {
+    ) -> Result<(), CertificateInteractionError> {
         let mut sender = self.action_sender.lock()?;
         if let Some(sender) = sender.take() {
             match sender.send(action) {
                 Ok(_) => Ok(()),
-                Err(_) => Err(QuinnetError::InternalChannelClosed),
+                Err(_) => Err(AsyncChannelError::InternalChannelClosed.into()),
             }
         } else {
-            Err(QuinnetError::CertificateActionAlreadyApplied)
+            Err(CertificateInteractionError::CertificateActionAlreadyApplied)
         }
     }
 }
@@ -446,15 +449,15 @@ fn parse_known_host_line(
 ) -> Result<(ServerName, CertificateFingerprint), Box<dyn Error>> {
     let mut parts = line.split_whitespace();
 
-    let adr_str = parts.next().ok_or(QuinnetError::InvalidHostFile)?;
+    let adr_str = parts.next().ok_or(InvalidHostFile)?;
     let serv_name = ServerName(RustlsServerName::try_from(adr_str)?.to_owned());
 
-    let fingerprint_b64 = parts.next().ok_or(QuinnetError::InvalidHostFile)?;
+    let fingerprint_b64 = parts.next().ok_or(InvalidHostFile)?;
     let fingerprint_bytes = base64::decode(&fingerprint_b64)?;
 
     match fingerprint_bytes.try_into() {
         Ok(buf) => Ok((serv_name, CertificateFingerprint::new(buf))),
-        Err(_) => Err(Box::new(QuinnetError::InvalidHostFile)),
+        Err(_) => Err(Box::new(InvalidHostFile)),
     }
 }
 

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -4,8 +4,9 @@ use crate::shared::{channels::ChannelId, error::AsyncChannelError};
 
 use super::connection::ConnectionLocalId;
 
+/// Error when sending data from the client
 #[derive(thiserror::Error, Debug)]
-pub enum SendError {
+pub enum ClientSendError {
     /// A connection is closed
     #[error("Connection is 'disconnected'")]
     ConnectionClosed,
@@ -15,58 +16,55 @@ pub enum SendError {
     /// A channel is closed
     #[error("Channel is closed")]
     ChannelClosed,
-
-    #[error("TODO")]
+    /// Quinnet async channel error
+    #[error("Quinnet async channel error")]
     ChannelSendError(#[from] AsyncChannelError),
 }
 
+/// Error when sending a payload from the client
 #[derive(thiserror::Error, Debug)]
-pub enum PayloadSendError {
+pub enum ClientPayloadSendError {
     /// There is no default channel
     #[error("There is no default channel")]
     NoDefaultChannel,
-
-    #[error("TODO")]
-    SendError(#[from] SendError),
+    /// Error when sending
+    #[error("Error when sending")]
+    SendError(#[from] ClientSendError),
 }
 
+/// Error when sending a message to be serialized from the client
 #[derive(thiserror::Error, Debug)]
-pub enum MessageSendError {
+pub enum ClientMessageSendError {
     /// Failed serialization
     #[error("Failed serialization")]
     Serialization,
     /// There is no default channel
     #[error("There is no default channel")]
     NoDefaultChannel,
-
-    #[error("TODO")]
-    SendError(#[from] SendError),
+    /// Error when sending data
+    #[error("Error when sending data")]
+    SendError(#[from] ClientSendError),
 }
 
+/// Error while receiving a message on the client
 #[derive(thiserror::Error, Debug)]
-pub enum MessageReceiveError {
+pub enum ClientMessageReceiveError {
     /// Failed deserialization
     #[error("Failed deserialization")]
     Deserialization,
-
-    #[error("TODO")]
-    ReceiveError(#[from] ReceiveError),
+    /// Error while receiving data
+    #[error("Error while receiving data")]
+    ConnectionClosed(#[from] ConnectionClosed),
 }
 
+/// The client connection is closed
 #[derive(thiserror::Error, Debug)]
-pub enum ReceiveError {
-    /// A connection is closed
-    #[error("Connection is 'disconnected'")]
-    ConnectionClosed,
-    /// The receiving half of an internal channel was explicitly closed or has been dropped
-    #[error(
-        "The receiving half of the internal channel was explicitly closed or has been dropped"
-    )]
-    InternalChannelClosed,
-}
+#[error("The client connection is closed")]
+pub struct ConnectionClosed;
 
+/// Error while closing a connection
 #[derive(thiserror::Error, Debug)]
-pub enum ConnectionCloseError {
+pub enum ClientConnectionCloseError {
     /// A connection is already closed
     #[error("Connection is already closed")]
     ConnectionAlreadyClosed,
@@ -80,6 +78,7 @@ pub enum ConnectionCloseError {
 #[error("The hosts file is invalid")]
 pub struct InvalidHostFile;
 
+/// Error while applying a certificate action
 #[derive(thiserror::Error, Debug)]
 pub enum CertificateInteractionError {
     /// A Certificate action was already sent for a CertificateInteractionEvent
@@ -88,8 +87,8 @@ pub enum CertificateInteractionError {
     /// A lock acquisition failed
     #[error("Lock acquisition failure")]
     LockAcquisitionFailure,
-
-    #[error("TODO")]
+    /// Quinnet async channel error
+    #[error("Quinnet async channel error")]
     AsyncChannelError(#[from] AsyncChannelError),
 }
 

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -1,0 +1,100 @@
+use std::sync::PoisonError;
+
+use crate::shared::{channels::ChannelId, error::AsyncChannelError};
+
+use super::connection::ConnectionLocalId;
+
+#[derive(thiserror::Error, Debug)]
+pub enum SendError {
+    /// A connection is closed
+    #[error("Connection is 'disconnected'")]
+    ConnectionClosed,
+    /// A channel id is invalid
+    #[error("Channel with id `{0}` is invalid")]
+    InvalidChannelId(ChannelId),
+    /// A channel is closed
+    #[error("Channel is closed")]
+    ChannelClosed,
+
+    #[error("TODO")]
+    ChannelSendError(#[from] AsyncChannelError),
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum PayloadSendError {
+    /// There is no default channel
+    #[error("There is no default channel")]
+    NoDefaultChannel,
+
+    #[error("TODO")]
+    SendError(#[from] SendError),
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum MessageSendError {
+    /// Failed serialization
+    #[error("Failed serialization")]
+    Serialization,
+    /// There is no default channel
+    #[error("There is no default channel")]
+    NoDefaultChannel,
+
+    #[error("TODO")]
+    SendError(#[from] SendError),
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum MessageReceiveError {
+    /// Failed deserialization
+    #[error("Failed deserialization")]
+    Deserialization,
+
+    #[error("TODO")]
+    ReceiveError(#[from] ReceiveError),
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ReceiveError {
+    /// A connection is closed
+    #[error("Connection is 'disconnected'")]
+    ConnectionClosed,
+    /// The receiving half of an internal channel was explicitly closed or has been dropped
+    #[error(
+        "The receiving half of the internal channel was explicitly closed or has been dropped"
+    )]
+    InternalChannelClosed,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ConnectionCloseError {
+    /// A connection is already closed
+    #[error("Connection is already closed")]
+    ConnectionAlreadyClosed,
+    /// A connection id is invalid
+    #[error("Connection id `{0}` is invalid")]
+    InvalidConnectionId(ConnectionLocalId),
+}
+
+#[derive(thiserror::Error, Debug)]
+/// An host file is invalid
+#[error("The hosts file is invalid")]
+pub struct InvalidHostFile;
+
+#[derive(thiserror::Error, Debug)]
+pub enum CertificateInteractionError {
+    /// A Certificate action was already sent for a CertificateInteractionEvent
+    #[error("A Certificate action was already sent for a CertificateInteractionEvent")]
+    CertificateActionAlreadyApplied,
+    /// A lock acquisition failed
+    #[error("Lock acquisition failure")]
+    LockAcquisitionFailure,
+
+    #[error("TODO")]
+    AsyncChannelError(#[from] AsyncChannelError),
+}
+
+impl<T> From<PoisonError<T>> for CertificateInteractionError {
+    fn from(_: PoisonError<T>) -> Self {
+        Self::LockAcquisitionFailure
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -24,13 +24,15 @@ use crate::{
     server::certificate::{retrieve_certificate, CertificateRetrievalMode, ServerCertificate},
     shared::{
         channels::{
-            spawn_recv_channels_tasks, spawn_send_channels_tasks, Channel, ChannelAsyncMessage,
-            ChannelId, ChannelKind, ChannelSyncMessage, ChannelsConfiguration, CloseReason,
+            spawn_recv_channels_tasks, spawn_send_channels_tasks_spawner, Channel,
+            ChannelAsyncMessage, ChannelId, ChannelKind, ChannelSyncMessage, ChannelsConfiguration,
+            CloseReason,
         },
-        error::QuinnetError,
+        error::{AsyncChannelError, ChannelCloseError, ChannelCreationError},
         AsyncRuntime, ClientId, InternalConnectionRef, QuinnetSyncUpdate,
-        DEFAULT_INTERNAL_MESSAGE_CHANNEL_SIZE, DEFAULT_KEEP_ALIVE_INTERVAL_S,
+        DEFAULT_INTERNAL_MESSAGES_CHANNEL_SIZE, DEFAULT_KEEP_ALIVE_INTERVAL_S,
         DEFAULT_KILL_MESSAGE_QUEUE_SIZE, DEFAULT_MESSAGE_QUEUE_SIZE,
+        DEFAULT_QCHANNEL_MESSAGES_CHANNEL_SIZE,
     },
 };
 
@@ -39,6 +41,9 @@ use crate::server::client_id::spawn_client_id_sender;
 
 #[cfg(feature = "shared-client-id")]
 mod client_id;
+
+mod error;
+pub use error::*;
 
 /// Module for the server's certificate features
 pub mod certificate;
@@ -183,22 +188,32 @@ impl ServerSideConnection {
     /// Immediately prevents new messages from being sent on the channel and signal the channel to closes all its background tasks.
     /// Before trully closing, the channel will wait for all buffered messages to be properly sent according to the channel type.
     /// Can fail if the [ChannelId] is unknown, or if the channel is already closed.
-    pub(crate) fn close_channel(&mut self, channel_id: ChannelId) -> Result<(), QuinnetError> {
+    pub(crate) fn close_channel(&mut self, channel_id: ChannelId) -> Result<(), ChannelCloseError> {
         if (channel_id as usize) < self.channels.len() {
             match self.channels[channel_id as usize].take() {
                 Some(channel) => channel.close(),
-                None => Err(QuinnetError::ChannelClosed),
+                None => Err(ChannelCloseError::ChannelAlreadyClosed),
             }
         } else {
-            Err(QuinnetError::UnknownChannel(channel_id))
+            Err(ChannelCloseError::InvalidChannelId(channel_id))
         }
     }
 
-    pub(crate) fn create_channel(
+    pub(crate) fn create_connection_channel(
         &mut self,
-        channel_id: ChannelId,
-        channel_type: ChannelKind,
-    ) -> Result<ChannelId, QuinnetError> {
+        id: ChannelId,
+        kind: ChannelKind,
+    ) -> Result<(), AsyncChannelError> {
+        let channel = self.create_unregistered_connection_channel(id, kind)?;
+        self.register_connection_channel(channel);
+        Ok(())
+    }
+
+    pub(crate) fn create_unregistered_connection_channel(
+        &mut self,
+        id: ChannelId,
+        kind: ChannelKind,
+    ) -> Result<Channel, AsyncChannelError> {
         let (bytes_to_channel_send, bytes_to_channel_recv) =
             mpsc::channel::<Bytes>(DEFAULT_MESSAGE_QUEUE_SIZE);
         let (channel_close_send, channel_close_recv) =
@@ -207,38 +222,37 @@ impl ServerSideConnection {
         match self
             .to_channels_send
             .try_send(ChannelSyncMessage::CreateChannel {
-                id: channel_id,
-                kind: channel_type,
+                id,
+                kind,
                 bytes_to_channel_recv,
                 channel_close_recv,
             }) {
-            Ok(_) => {
-                let channel = Some(Channel::new(bytes_to_channel_send, channel_close_send));
-                if (channel_id as usize) < self.channels.len() {
-                    self.channels[channel_id as usize] = channel;
-                } else {
-                    for _ in self.channels.len()..channel_id as usize {
-                        self.channels.push(None);
-                    }
-                    self.channels.push(channel);
-                }
-
-                Ok(channel_id)
-            }
+            Ok(_) => Ok(Channel::new(id, bytes_to_channel_send, channel_close_send)),
             Err(err) => match err {
-                TrySendError::Full(_) => Err(QuinnetError::FullQueue),
-                TrySendError::Closed(_) => Err(QuinnetError::InternalChannelClosed),
+                TrySendError::Full(_) => Err(AsyncChannelError::FullQueue),
+                TrySendError::Closed(_) => Err(AsyncChannelError::InternalChannelClosed),
             },
         }
     }
 
+    pub(crate) fn register_connection_channel(&mut self, channel: Channel) {
+        let channel_index = channel.id() as usize;
+        if channel_index < self.channels.len() {
+            self.channels[channel_index] = Some(channel);
+        } else {
+            self.channels
+                .extend((self.channels.len()..channel_index).map(|_| None));
+            self.channels.push(Some(channel));
+        }
+    }
+
     /// Signal the connection to closes all its background tasks. Before trully closing, the connection will wait for all buffered messages in all its opened channels to be properly sent according to their respective channel type.
-    pub(crate) fn close(&mut self) -> Result<(), QuinnetError> {
+    pub(crate) fn close(&mut self) -> Result<(), ConnectionCloseError> {
         match self.close_sender.send(CloseReason::LocalOrder) {
             Ok(_) => Ok(()),
             Err(_) => {
                 // The only possible error for a send is that there is no active receivers, meaning that the tasks are already terminated.
-                Err(QuinnetError::ConnectionAlreadyClosed)
+                Err(ConnectionCloseError::ConnectionAlreadyClosed)
             }
         }
     }
@@ -297,7 +311,7 @@ pub struct Endpoint {
 
     close_sender: broadcast::Sender<()>,
 
-    pub(crate) from_async_server_recv: mpsc::Receiver<ServerAsyncMessage>,
+    from_async_endpoint_recv: mpsc::Receiver<ServerAsyncMessage>,
 
     stats: EndpointStats,
 }
@@ -327,7 +341,7 @@ impl EndpointStats {
 impl Endpoint {
     fn new(
         endpoint_close_send: broadcast::Sender<()>,
-        from_async_server_recv: mpsc::Receiver<ServerAsyncMessage>,
+        from_async_endpoint_recv: mpsc::Receiver<ServerAsyncMessage>,
     ) -> Self {
         Self {
             clients: HashMap::new(),
@@ -336,7 +350,7 @@ impl Endpoint {
             default_channel: None,
             available_channel_ids: (0..255).collect(),
             close_sender: endpoint_close_send,
-            from_async_server_recv,
+            from_async_endpoint_recv,
             stats: default(),
         }
     }
@@ -354,11 +368,11 @@ impl Endpoint {
     pub fn receive_message_from<T: serde::de::DeserializeOwned>(
         &mut self,
         client_id: ClientId,
-    ) -> Result<Option<(ChannelId, T)>, QuinnetError> {
+    ) -> Result<Option<(ChannelId, T)>, MessageReceiveError> {
         match self.receive_payload_from(client_id)? {
             Some((channel_id, payload)) => match bincode::deserialize(&payload) {
                 Ok(msg) => Ok(Some((channel_id, msg))),
-                Err(_) => Err(QuinnetError::Deserialization),
+                Err(_) => Err(MessageReceiveError::Deserialization),
             },
             None => Ok(None),
         }
@@ -388,7 +402,7 @@ impl Endpoint {
     pub fn receive_payload_from(
         &mut self,
         client_id: ClientId,
-    ) -> Result<Option<(ChannelId, Bytes)>, QuinnetError> {
+    ) -> Result<Option<(ChannelId, Bytes)>, ReceiveError> {
         match self.clients.get_mut(&client_id) {
             Some(client) => match client.bytes_from_client_recv.try_recv() {
                 Ok(msg) => {
@@ -398,10 +412,10 @@ impl Endpoint {
                 }
                 Err(err) => match err {
                     TryRecvError::Empty => Ok(None),
-                    TryRecvError::Disconnected => Err(QuinnetError::InternalChannelClosed),
+                    TryRecvError::Disconnected => Err(ReceiveError::InternalChannelClosed),
                 },
             },
-            None => Err(QuinnetError::UnknownClient(client_id)),
+            None => Err(ReceiveError::UnknownClient(client_id)),
         }
     }
 
@@ -421,10 +435,10 @@ impl Endpoint {
         &mut self,
         client_id: ClientId,
         message: T,
-    ) -> Result<(), QuinnetError> {
+    ) -> Result<(), MessageSendError> {
         match self.default_channel {
             Some(channel) => self.send_message_on(client_id, channel, message),
-            None => Err(QuinnetError::NoDefaultChannel),
+            None => Err(MessageSendError::NoDefaultChannel),
         }
     }
 
@@ -440,10 +454,10 @@ impl Endpoint {
         client_id: ClientId,
         channel_id: C,
         message: T,
-    ) -> Result<(), QuinnetError> {
+    ) -> Result<(), MessageSendError> {
         match bincode::serialize(&message) {
             Ok(payload) => Ok(self.send_payload_on(client_id, channel_id, payload)?),
-            Err(_) => Err(QuinnetError::Serialization),
+            Err(_) => Err(MessageSendError::Serialization),
         }
     }
 
@@ -473,10 +487,10 @@ impl Endpoint {
         &mut self,
         client_ids: I,
         message: T,
-    ) -> Result<(), QuinnetError> {
+    ) -> Result<(), MessageSendError> {
         match self.default_channel {
             Some(channel) => self.send_group_message_on(client_ids, channel, message),
-            None => Err(QuinnetError::NoDefaultChannel),
+            None => Err(MessageSendError::NoDefaultChannel),
         }
     }
 
@@ -497,7 +511,7 @@ impl Endpoint {
         client_ids: I,
         channel_id: C,
         message: T,
-    ) -> Result<(), QuinnetError> {
+    ) -> Result<(), MessageSendError> {
         let channel_id = channel_id.into();
         match bincode::serialize(&message) {
             Ok(payload) => {
@@ -507,7 +521,7 @@ impl Endpoint {
                 }
                 Ok(())
             }
-            Err(_) => Err(QuinnetError::Serialization),
+            Err(_) => Err(MessageSendError::Serialization),
         }
     }
 
@@ -545,10 +559,10 @@ impl Endpoint {
     pub fn broadcast_message<T: serde::Serialize>(
         &mut self,
         message: T,
-    ) -> Result<(), QuinnetError> {
+    ) -> Result<(), GroupMessageSendError> {
         match self.default_channel {
             Some(channel) => self.broadcast_message_on(channel, message),
-            None => Err(QuinnetError::NoDefaultChannel),
+            None => Err(GroupMessageSendError::NoDefaultChannel),
         }
     }
 
@@ -562,10 +576,10 @@ impl Endpoint {
         &mut self,
         channel_id: C,
         message: T,
-    ) -> Result<(), QuinnetError> {
+    ) -> Result<(), GroupMessageSendError> {
         match bincode::serialize(&message) {
             Ok(payload) => Ok(self.broadcast_payload_on(channel_id, payload)?),
-            Err(_) => Err(QuinnetError::Serialization),
+            Err(_) => Err(GroupMessageSendError::Serialization),
         }
     }
 
@@ -590,10 +604,13 @@ impl Endpoint {
     }
 
     /// Same as [Endpoint::broadcast_payload_on] but on the default channel
-    pub fn broadcast_payload<T: Into<Bytes>>(&mut self, payload: T) -> Result<(), QuinnetError> {
+    pub fn broadcast_payload<T: Into<Bytes>>(
+        &mut self,
+        payload: T,
+    ) -> Result<(), GroupPayloadSendError> {
         match self.default_channel {
-            Some(channel) => self.broadcast_payload_on(channel, payload),
-            None => Err(QuinnetError::NoDefaultChannel),
+            Some(channel) => Ok(self.broadcast_payload_on(channel, payload)?),
+            None => Err(GroupPayloadSendError::NoDefaultChannel),
         }
     }
 
@@ -606,20 +623,27 @@ impl Endpoint {
         &mut self,
         channel_id: C,
         payload: T,
-    ) -> Result<(), QuinnetError> {
+    ) -> Result<(), GroupSendError> {
         let payload: Bytes = payload.into();
         let channel_id = channel_id.into();
-        for client_connection in self.clients.values_mut() {
-            match client_connection.channels.get(channel_id as usize) {
+
+        let mut errs = vec![];
+        for (&client_id, server_side_connection) in self.clients.iter_mut() {
+            match server_side_connection.channels.get(channel_id as usize) {
                 Some(Some(channel)) => {
-                    client_connection.sent_bytes_count += payload.len();
-                    channel.send_payload(payload.clone())?
+                    match channel.send_payload(payload.clone()) {
+                        Ok(_) => server_side_connection.sent_bytes_count += payload.len(),
+                        Err(e) => errs.push((client_id, e.into())),
+                    };
                 }
-                Some(None) => return Err(QuinnetError::ChannelClosed),
-                None => return Err(QuinnetError::UnknownChannel(channel_id)),
+                Some(None) => errs.push((client_id, SendError::ChannelClosed)),
+                None => errs.push((client_id, SendError::InvalidChannelId(channel_id))),
             };
         }
-        Ok(())
+        match errs.is_empty() {
+            true => Ok(()),
+            false => Err(GroupSendError(errs)),
+        }
     }
 
     /// Same as [Endpoint::broadcast_payload] but will log the error instead of returning it
@@ -647,10 +671,10 @@ impl Endpoint {
         &mut self,
         client_id: ClientId,
         payload: T,
-    ) -> Result<(), QuinnetError> {
+    ) -> Result<(), PayloadSendError> {
         match self.default_channel {
-            Some(channel) => self.send_payload_on(client_id, channel, payload),
-            None => Err(QuinnetError::NoDefaultChannel),
+            Some(channel) => Ok(self.send_payload_on(client_id, channel, payload)?),
+            None => Err(PayloadSendError::NoDefaultChannel.into()),
         }
     }
 
@@ -665,20 +689,20 @@ impl Endpoint {
         client_id: ClientId,
         channel_id: C,
         payload: T,
-    ) -> Result<(), QuinnetError> {
+    ) -> Result<(), SendError> {
         let channel_id = channel_id.into();
         if let Some(client_connection) = self.clients.get_mut(&client_id) {
             match client_connection.channels.get(channel_id as usize) {
                 Some(Some(channel)) => {
                     let bytes = payload.into();
                     client_connection.sent_bytes_count += bytes.len();
-                    channel.send_payload(bytes)
+                    Ok(channel.send_payload(bytes)?)
                 }
-                Some(None) => return Err(QuinnetError::ChannelClosed),
-                None => return Err(QuinnetError::UnknownChannel(channel_id)),
+                Some(None) => return Err(SendError::ChannelClosed),
+                None => return Err(SendError::InvalidChannelId(channel_id)),
             }
         } else {
-            Err(QuinnetError::UnknownClient(client_id))
+            Err(SendError::UnknownClient(client_id))
         }
     }
 
@@ -707,13 +731,13 @@ impl Endpoint {
         &mut self,
         client_id: ClientId,
         reason: CloseReason,
-    ) -> Result<(), QuinnetError> {
+    ) -> Result<(), DisconnectError> {
         match self.clients.remove(&client_id) {
             Some(client_connection) => match client_connection.close_sender.send(reason) {
                 Ok(_) => Ok(()),
-                Err(_) => Err(QuinnetError::ClientAlreadyDisconnected(client_id)),
+                Err(_) => Err(DisconnectError::ClientAlreadyDisconnected(client_id)),
             },
-            None => Err(QuinnetError::UnknownClient(client_id)),
+            None => Err(DisconnectError::UnknownClient(client_id)),
         }
     }
 
@@ -733,7 +757,7 @@ impl Endpoint {
     /// Disconnecting a client immediately prevents new messages from being sent on its connection and signal the underlying connection to closes all its background tasks. Before trully closing, the connection will wait for all buffered messages in all its opened channels to be properly sent according to their respective channel type.
     ///
     /// This may fail if no client if found for client_id, or if the client is already disconnected.
-    pub fn disconnect_client(&mut self, client_id: ClientId) -> Result<(), QuinnetError> {
+    pub fn disconnect_client(&mut self, client_id: ClientId) -> Result<(), DisconnectError> {
         self.internal_disconnect_client(client_id, CloseReason::LocalOrder)
     }
 
@@ -748,12 +772,11 @@ impl Endpoint {
         }
     }
 
-    /// Calls [Endpoint::disconnect_client] on all connected clients
-    pub fn disconnect_all_clients(&mut self) -> Result<(), QuinnetError> {
-        for client_id in self.clients.keys().cloned().collect::<Vec<ClientId>>() {
-            self.disconnect_client(client_id)?;
+    /// Disconnects all connect clients
+    pub fn disconnect_all_clients(&mut self) {
+        for (_, client_connection) in self.clients.drain() {
+            let _ = client_connection.close_sender.send(CloseReason::LocalOrder);
         }
-        Ok(())
     }
 
     /// Returns statistics about a client if connected.
@@ -789,20 +812,74 @@ impl Endpoint {
     ///
     /// If no channels were previously opened, the opened channel will be the new default channel.
     ///
-    /// Can fail if the Endpoint is closed.
-    pub fn open_channel(&mut self, channel_type: ChannelKind) -> Result<ChannelId, QuinnetError> {
+    /// Can fail if the Endpoint is closed or if too many channels are already opened.
+    pub fn open_channel(
+        &mut self,
+        channel_type: ChannelKind,
+    ) -> Result<ChannelId, ChannelCreationError> {
         let channel_id = match self.available_channel_ids.pop_first() {
             Some(channel_id) => channel_id,
-            None => return Err(QuinnetError::MaxChannelsCountReached),
+            None => return Err(ChannelCreationError::MaxChannelsCountReached),
         };
-        match self.create_channel(channel_id, channel_type) {
+        match self.create_endpoint_channel(channel_id, channel_type) {
             Ok(channel_id) => Ok(channel_id),
             Err(err) => {
-                // Reinsert the popped channel id
+                self.available_channel_ids.insert(channel_id);
+                Err(err.into())
+            }
+        }
+    }
+
+    /// Assumes presence of available ids in `available_channel_ids`
+    fn unchecked_open_channel(
+        &mut self,
+        channel_type: ChannelKind,
+    ) -> Result<ChannelId, AsyncChannelError> {
+        let channel_id = self.available_channel_ids.pop_first().unwrap();
+        match self.create_endpoint_channel(channel_id, channel_type) {
+            Ok(channel_id) => Ok(channel_id),
+            Err(err) => {
                 self.available_channel_ids.insert(channel_id);
                 Err(err)
             }
         }
+    }
+
+    /// `channel_id` must be an available [ChannelId]
+    fn create_endpoint_channel(
+        &mut self,
+        channel_id: ChannelId,
+        channel_type: ChannelKind,
+    ) -> Result<ChannelId, AsyncChannelError> {
+        let unregistered_channels =
+            self.create_unregistered_endpoint_channels(channel_id, channel_type)?;
+        // Only commit the changes once all channels have been confirmed to be created.
+        for (client_id, channel) in unregistered_channels {
+            self.clients
+                .get_mut(&client_id)
+                .unwrap()
+                .register_connection_channel(channel);
+        }
+        self.opened_channels.insert(channel_id, channel_type);
+        if self.default_channel.is_none() {
+            self.default_channel = Some(channel_id);
+        }
+        Ok(channel_id)
+    }
+
+    fn create_unregistered_endpoint_channels(
+        &mut self,
+        channel_id: ChannelId,
+        channel_type: ChannelKind,
+    ) -> Result<HashMap<ClientId, Channel>, AsyncChannelError> {
+        let mut unregistered_channels = HashMap::new();
+        for (&client_id, client_connection) in self.clients.iter_mut() {
+            // Unregistered channels are dropped here on error, created async tasks are closing too.
+            let channel = client_connection
+                .create_unregistered_connection_channel(channel_id, channel_type)?;
+            unregistered_channels.insert(client_id, channel);
+        }
+        Ok(unregistered_channels)
     }
 
     /// Closes the channel with the corresponding [ChannelId].
@@ -812,7 +889,7 @@ impl Endpoint {
     /// If the closed channel is the current default channel, the default channel gets set to `None`.
     ///
     /// Can fail if the [ChannelId] is unknown, or if the channel is already closed.
-    pub fn close_channel(&mut self, channel_id: ChannelId) -> Result<(), QuinnetError> {
+    pub fn close_channel(&mut self, channel_id: ChannelId) -> Result<(), ChannelCloseError> {
         match self.opened_channels.remove(&channel_id) {
             Some(_) => {
                 if Some(channel_id) == self.default_channel {
@@ -824,7 +901,7 @@ impl Endpoint {
                 self.available_channel_ids.insert(channel_id);
                 Ok(())
             }
-            None => Err(QuinnetError::UnknownChannel(channel_id)),
+            None => Err(ChannelCloseError::InvalidChannelId(channel_id)),
         }
     }
 
@@ -838,35 +915,20 @@ impl Endpoint {
         self.default_channel
     }
 
-    /// `channel_id` must be an available [ChannelId]
-    fn create_channel(
-        &mut self,
-        channel_id: ChannelId,
-        channel_type: ChannelKind,
-    ) -> Result<ChannelId, QuinnetError> {
-        for (_, client_connection) in self.clients.iter_mut() {
-            client_connection.create_channel(channel_id, channel_type)?;
-        }
-        self.opened_channels.insert(channel_id, channel_type);
-        if self.default_channel.is_none() {
-            self.default_channel = Some(channel_id);
-        }
-        Ok(channel_id)
-    }
-
-    fn close_incoming_connections_handler(&mut self) -> Result<(), QuinnetError> {
+    fn close_incoming_connections_handler(&mut self) -> Result<(), AsyncChannelError> {
         match self.close_sender.send(()) {
             Ok(_) => Ok(()),
-            Err(_) => Err(QuinnetError::InternalChannelClosed),
+            // Connections handler is already closed
+            Err(_) => Err(AsyncChannelError::InternalChannelClosed),
         }
     }
 
     fn handle_connection(
         &mut self,
         mut connection: ServerSideConnection,
-    ) -> Result<ClientId, QuinnetError> {
+    ) -> Result<ClientId, AsyncChannelError> {
         for (channel_id, channel_type) in self.opened_channels.iter() {
-            if let Err(err) = connection.create_channel(*channel_id, *channel_type) {
+            if let Err(err) = connection.create_connection_channel(*channel_id, *channel_type) {
                 connection.try_close();
                 return Err(err);
             };
@@ -885,7 +947,7 @@ impl Endpoint {
             }
             Err(_) => {
                 connection.try_close();
-                Err(QuinnetError::InternalChannelClosed)
+                Err(AsyncChannelError::InternalChannelClosed)
             }
         }
     }
@@ -955,7 +1017,7 @@ impl QuinnetServer {
         config: ServerEndpointConfiguration,
         cert_mode: CertificateRetrievalMode,
         channels_config: ChannelsConfiguration,
-    ) -> Result<ServerCertificate, QuinnetError> {
+    ) -> Result<ServerCertificate, EndpointStartError> {
         // Endpoint configuration
         let server_cert = retrieve_certificate(cert_mode)?;
         let mut endpoint_config = ServerConfig::with_single_cert(
@@ -963,11 +1025,11 @@ impl QuinnetServer {
             server_cert.priv_key.clone_key(),
         )?;
         Arc::get_mut(&mut endpoint_config.transport)
-            .ok_or(QuinnetError::LockAcquisitionFailure)?
+            .ok_or(EndpointStartError::LockAcquisitionFailure)?
             .keep_alive_interval(Some(DEFAULT_KEEP_ALIVE_INTERVAL_S));
 
-        let (to_sync_server_send, from_async_server_recv) =
-            mpsc::channel::<ServerAsyncMessage>(DEFAULT_INTERNAL_MESSAGE_CHANNEL_SIZE);
+        let (to_sync_endpoint_send, from_async_endpoint_recv) =
+            mpsc::channel::<ServerAsyncMessage>(DEFAULT_INTERNAL_MESSAGES_CHANNEL_SIZE);
         let (endpoint_close_send, endpoint_close_recv) =
             broadcast::channel(DEFAULT_KILL_MESSAGE_QUEUE_SIZE);
 
@@ -978,15 +1040,15 @@ impl QuinnetServer {
             endpoint_task(
                 socket,
                 endpoint_config,
-                to_sync_server_send.clone(),
+                to_sync_endpoint_send.clone(),
                 endpoint_close_recv,
             )
             .await;
         });
 
-        let mut endpoint = Endpoint::new(endpoint_close_send, from_async_server_recv);
+        let mut endpoint = Endpoint::new(endpoint_close_send, from_async_endpoint_recv);
         for channel_type in channels_config.configs() {
-            endpoint.open_channel(*channel_type)?;
+            endpoint.unchecked_open_channel(*channel_type)?;
         }
 
         self.endpoint = Some(endpoint);
@@ -996,14 +1058,17 @@ impl QuinnetServer {
 
     /// Closes the endpoint and all the connections associated with it
     ///
-    /// Returns [`QuinnetError::EndpointAlreadyClosed`] if the endpoint is already closed
-    pub fn stop_endpoint(&mut self) -> Result<(), QuinnetError> {
+    /// Returns [`EndpointAlreadyClosed`] if the endpoint is already closed
+    pub fn stop_endpoint(&mut self) -> Result<(), EndpointAlreadyClosed> {
         match self.endpoint.take() {
             Some(mut endpoint) => {
-                endpoint.close_incoming_connections_handler()?;
-                endpoint.disconnect_all_clients()
+                endpoint.disconnect_all_clients();
+                match endpoint.close_incoming_connections_handler() {
+                    Ok(_) => Ok(()),
+                    Err(_) => Err(EndpointAlreadyClosed),
+                }
             }
-            None => Err(QuinnetError::EndpointAlreadyClosed),
+            None => Err(EndpointAlreadyClosed),
         }
     }
 
@@ -1019,7 +1084,7 @@ impl QuinnetServer {
 async fn endpoint_task(
     socket: UdpSocket,
     endpoint_config: ServerConfig,
-    to_sync_server_send: mpsc::Sender<ServerAsyncMessage>,
+    to_sync_endpoint_send: mpsc::Sender<ServerAsyncMessage>,
     mut endpoint_close_recv: broadcast::Receiver<()>,
 ) {
     let endpoint = QuinnEndpoint::new(
@@ -1040,11 +1105,11 @@ async fn endpoint_task(
                 match connecting.await {
                     Err(err) => error!("An incoming connection failed: {}", err),
                     Ok(connection) => {
-                        let to_sync_server_send = to_sync_server_send.clone();
+                        let to_sync_endpoint_send = to_sync_endpoint_send.clone();
                         tokio::spawn(async move {
                             client_connection_task(
                                 connection,
-                                to_sync_server_send
+                                to_sync_endpoint_send
                             )
                             .await
                         });
@@ -1057,21 +1122,21 @@ async fn endpoint_task(
 
 async fn client_connection_task(
     connection_handle: quinn::Connection,
-    to_sync_server_send: mpsc::Sender<ServerAsyncMessage>,
+    to_sync_endpoint_send: mpsc::Sender<ServerAsyncMessage>,
 ) {
     let (client_close_send, client_close_recv) =
         broadcast::channel(DEFAULT_KILL_MESSAGE_QUEUE_SIZE);
     let (bytes_from_client_send, bytes_from_client_recv) =
         mpsc::channel::<(ChannelId, Bytes)>(DEFAULT_MESSAGE_QUEUE_SIZE);
     let (to_connection_send, mut from_sync_server_recv) =
-        mpsc::channel::<ServerSyncMessage>(DEFAULT_INTERNAL_MESSAGE_CHANNEL_SIZE);
+        mpsc::channel::<ServerSyncMessage>(DEFAULT_INTERNAL_MESSAGES_CHANNEL_SIZE);
     let (from_channels_send, from_channels_recv) =
-        mpsc::channel::<ChannelAsyncMessage>(DEFAULT_INTERNAL_MESSAGE_CHANNEL_SIZE);
+        mpsc::channel::<ChannelAsyncMessage>(DEFAULT_INTERNAL_MESSAGES_CHANNEL_SIZE);
     let (to_channels_send, to_channels_recv) =
-        mpsc::channel::<ChannelSyncMessage>(DEFAULT_INTERNAL_MESSAGE_CHANNEL_SIZE);
+        mpsc::channel::<ChannelSyncMessage>(DEFAULT_QCHANNEL_MESSAGES_CHANNEL_SIZE);
 
     // Signal the sync server of this new connection
-    to_sync_server_send
+    to_sync_endpoint_send
         .send(ServerAsyncMessage::ClientConnected(
             ServerSideConnection::new(
                 connection_handle.clone(),
@@ -1104,7 +1169,7 @@ async fn client_connection_task(
             // Spawn a task to listen for the underlying connection being closed
             {
                 let conn = connection_handle.clone();
-                let to_sync_server = to_sync_server_send.clone();
+                let to_sync_server = to_sync_endpoint_send.clone();
                 tokio::spawn(async move {
                     let _conn_err = conn.closed().await;
                     info!("Connection {} closed: {}", client_id, _conn_err);
@@ -1125,7 +1190,7 @@ async fn client_connection_task(
                 bytes_from_client_send,
             );
 
-            spawn_send_channels_tasks(
+            spawn_send_channels_tasks_spawner(
                 connection_handle,
                 client_close_recv,
                 to_channels_recv,
@@ -1148,7 +1213,7 @@ pub fn update_sync_server(
     mut connection_lost_events: EventWriter<ConnectionLostEvent>,
 ) {
     if let Some(endpoint) = server.get_endpoint_mut() {
-        while let Ok(message) = endpoint.from_async_server_recv.try_recv() {
+        while let Ok(message) = endpoint.from_async_endpoint_recv.try_recv() {
             match message {
                 ServerAsyncMessage::ClientConnected(connection) => {
                     match endpoint.handle_connection(connection) {

--- a/src/server/certificate.rs
+++ b/src/server/certificate.rs
@@ -6,7 +6,7 @@ use std::{
 
 use bevy::log::{trace, warn};
 
-use super::CertificateError;
+use super::EndpointCertificateError;
 use crate::shared::certificate::CertificateFingerprint;
 
 /// Represents the origin of a certificate.
@@ -63,7 +63,7 @@ pub struct ServerCertificate {
 fn read_cert_from_files(
     cert_file: &String,
     key_file: &String,
-) -> Result<ServerCertificate, CertificateError> {
+) -> Result<ServerCertificate, EndpointCertificateError> {
     let mut cert_chain_reader = BufReader::new(File::open(cert_file)?);
     let cert_chain: Vec<rustls::pki_types::CertificateDer> =
         rustls_pemfile::certs(&mut cert_chain_reader).collect::<Result<_, _>>()?;
@@ -100,7 +100,7 @@ fn write_cert_to_files(
 
 fn generate_self_signed_certificate(
     server_host: &String,
-) -> Result<(ServerCertificate, rcgen::CertifiedKey), CertificateError> {
+) -> Result<(ServerCertificate, rcgen::CertifiedKey), EndpointCertificateError> {
     let generated = rcgen::generate_simple_self_signed(vec![server_host.into()])?;
 
     let priv_key_der =
@@ -120,7 +120,7 @@ fn generate_self_signed_certificate(
 
 pub(crate) fn retrieve_certificate(
     cert_mode: CertificateRetrievalMode,
-) -> Result<ServerCertificate, CertificateError> {
+) -> Result<ServerCertificate, EndpointCertificateError> {
     match cert_mode {
         CertificateRetrievalMode::GenerateSelfSigned { server_hostname } => {
             let (server_cert, _rcgen_cert) = generate_self_signed_certificate(&server_hostname)?;

--- a/src/server/certificate.rs
+++ b/src/server/certificate.rs
@@ -6,7 +6,8 @@ use std::{
 
 use bevy::log::{trace, warn};
 
-use crate::shared::{certificate::CertificateFingerprint, error::QuinnetError};
+use super::CertificateError;
+use crate::shared::certificate::CertificateFingerprint;
 
 /// Represents the origin of a certificate.
 #[derive(Debug, Clone)]
@@ -62,7 +63,7 @@ pub struct ServerCertificate {
 fn read_cert_from_files(
     cert_file: &String,
     key_file: &String,
-) -> Result<ServerCertificate, QuinnetError> {
+) -> Result<ServerCertificate, CertificateError> {
     let mut cert_chain_reader = BufReader::new(File::open(cert_file)?);
     let cert_chain: Vec<rustls::pki_types::CertificateDer> =
         rustls_pemfile::certs(&mut cert_chain_reader).collect::<Result<_, _>>()?;
@@ -84,7 +85,7 @@ fn write_cert_to_files(
     cert: &rcgen::CertifiedKey,
     cert_file: &String,
     key_file: &String,
-) -> Result<(), QuinnetError> {
+) -> std::io::Result<()> {
     for file in vec![cert_file, key_file] {
         if let Some(parent) = std::path::Path::new(file).parent() {
             std::fs::create_dir_all(parent)?;
@@ -99,7 +100,7 @@ fn write_cert_to_files(
 
 fn generate_self_signed_certificate(
     server_host: &String,
-) -> Result<(ServerCertificate, rcgen::CertifiedKey), QuinnetError> {
+) -> Result<(ServerCertificate, rcgen::CertifiedKey), CertificateError> {
     let generated = rcgen::generate_simple_self_signed(vec![server_host.into()])?;
 
     let priv_key_der =
@@ -119,7 +120,7 @@ fn generate_self_signed_certificate(
 
 pub(crate) fn retrieve_certificate(
     cert_mode: CertificateRetrievalMode,
-) -> Result<ServerCertificate, QuinnetError> {
+) -> Result<ServerCertificate, CertificateError> {
     match cert_mode {
         CertificateRetrievalMode::GenerateSelfSigned { server_hostname } => {
             let (server_cert, _rcgen_cert) = generate_self_signed_certificate(&server_hostname)?;

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -1,7 +1,8 @@
 use crate::shared::{channels::ChannelId, error::AsyncChannelError, ClientId};
 
+/// Error when sending data from the server
 #[derive(thiserror::Error, Debug)]
-pub enum SendError {
+pub enum ServerSendError {
     /// A client id is unknown
     #[error("Client with id `{0}` is unknown")]
     UnknownClient(ClientId),
@@ -11,85 +12,91 @@ pub enum SendError {
     /// A channel is closed
     #[error("Channel is closed")]
     ChannelClosed,
-
-    #[error("TODO")]
+    /// Quinnet async channel error
+    #[error("Quinnet async channel error")]
     ChannelSendError(#[from] AsyncChannelError),
 }
 
+/// Error while sending a payload on the server
 #[derive(thiserror::Error, Debug)]
-pub enum PayloadSendError {
+pub enum ServerPayloadSendError {
     /// There is no default channel
     #[error("There is no default channel")]
     NoDefaultChannel,
-
-    #[error("TODO")]
-    SendError(#[from] SendError),
+    /// Error when sending data
+    #[error("Error when sending data")]
+    SendError(#[from] ServerSendError),
 }
 
+/// Error while sending a message to deserialize on the server
 #[derive(thiserror::Error, Debug)]
-pub enum MessageSendError {
+pub enum ServerMessageSendError {
     /// Failed serialization
     #[error("Failed serialization")]
     Serialization,
     /// There is no default channel
     #[error("There is no default channel")]
     NoDefaultChannel,
-
-    #[error("TODO")]
-    SendError(#[from] SendError),
+    /// Error when sending data
+    #[error("Error when sending data")]
+    SendError(#[from] ServerSendError),
 }
 
+/// Error while sending data on the server to a group of clients
 #[derive(thiserror::Error, Debug)]
 #[error("Error while sending to multiple recipients")]
-pub struct GroupSendError(pub Vec<(ClientId, SendError)>);
+pub struct ServerGroupSendError(pub Vec<(ClientId, ServerSendError)>);
 
+/// Error while sending a payload on the server to a group of clients
 #[derive(thiserror::Error, Debug)]
-pub enum GroupPayloadSendError {
+pub enum ServerGroupPayloadSendError {
     /// There is no default channel
     #[error("There is no default channel")]
     NoDefaultChannel,
-
-    #[error("TODO")]
-    GroupSendError(#[from] GroupSendError),
+    /// Error while sending data to a group of clients
+    #[error("Error while sending data to a group of clients")]
+    GroupSendError(#[from] ServerGroupSendError),
 }
 
+/// Error while sending a message to deserialize on the server to a group of clients
 #[derive(thiserror::Error, Debug)]
-pub enum GroupMessageSendError {
+pub enum ServerGroupMessageSendError {
     /// Failed serialization
     #[error("Failed serialization")]
     Serialization,
     /// There is no default channel
     #[error("There is no default channel")]
     NoDefaultChannel,
-
-    #[error("TODO")]
-    GroupSendError(#[from] GroupSendError),
+    /// Error while sending data to a group of clients
+    #[error("Error while sending data to a group of clients")]
+    GroupSendError(#[from] ServerGroupSendError),
 }
 
+/// Error while receiving a message to deserialize on the server
 #[derive(thiserror::Error, Debug)]
-pub enum MessageReceiveError {
+pub enum ServerMessageReceiveError {
     /// Failed deserialization
     #[error("Failed deserialization")]
     Deserialization,
-
-    #[error("TODO")]
-    ReceiveError(#[from] ReceiveError),
+    /// Error while receiving data
+    #[error("Error while receiving data")]
+    ReceiveError(#[from] ServerReceiveError),
 }
 
+/// Error while receiving data on the server
 #[derive(thiserror::Error, Debug)]
-pub enum ReceiveError {
+pub enum ServerReceiveError {
     /// A client id is unknown
     #[error("Client with id `{0}` is unknown")]
     UnknownClient(ClientId),
-    /// The receiving half of an internal channel was explicitly closed or has been dropped
-    #[error(
-        "The receiving half of the internal channel was explicitly closed or has been dropped"
-    )]
-    InternalChannelClosed,
+    /// The connection is closed
+    #[error("The connection is closed")]
+    ConnectionClosed,
 }
 
+/// Error while disconnecting a client on the server
 #[derive(thiserror::Error, Debug)]
-pub enum DisconnectError {
+pub enum ServerDisconnectError {
     /// A client id is unknown
     #[error("Client with id `{0}` is unknown")]
     UnknownClient(ClientId),
@@ -98,13 +105,12 @@ pub enum DisconnectError {
     ClientAlreadyDisconnected(ClientId),
 }
 
-pub enum StopEndpointError {}
-
 /// Endpoint is already closed
 #[derive(thiserror::Error, Debug)]
 #[error("Endpoint is already closed")]
 pub struct EndpointAlreadyClosed;
 
+/// Error while starting an Endpoint
 #[derive(thiserror::Error, Debug)]
 pub enum EndpointStartError {
     /// A lock acquisition failed
@@ -115,17 +121,18 @@ pub enum EndpointStartError {
     IoError(#[from] std::io::Error),
     /// Certificate error
     #[error("Certificate error")]
-    CertificateError(#[from] CertificateError),
+    CertificateError(#[from] EndpointCertificateError),
     ///Rustls protocol error
     #[error("Rustls protocol error")]
     RustlsError(#[from] rustls::Error),
-
-    #[error("TODO")]
+    /// Quinnet async channel error
+    #[error("Quinnet async channel error")]
     AsyncChannelError(#[from] AsyncChannelError),
 }
 
+/// Error while retrieving a certificate on the server
 #[derive(thiserror::Error, Debug)]
-pub enum CertificateError {
+pub enum EndpointCertificateError {
     /// Failed to generate a self-signed certificate
     #[error("Failed to generate a self-signed certificate")]
     CertificateGenerationFailed(#[from] rcgen::Error),
@@ -134,9 +141,7 @@ pub enum CertificateError {
     IoError(#[from] std::io::Error),
 }
 
+/// Endpoint connection is already closed
 #[derive(thiserror::Error, Debug)]
-pub enum ConnectionCloseError {
-    /// A connection is already closed
-    #[error("Connection is already closed")]
-    ConnectionAlreadyClosed,
-}
+#[error("Endpoint connection is already closed")]
+pub(crate) struct EndpointConnectionAlreadyClosed;

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -1,0 +1,142 @@
+use crate::shared::{channels::ChannelId, error::AsyncChannelError, ClientId};
+
+#[derive(thiserror::Error, Debug)]
+pub enum SendError {
+    /// A client id is unknown
+    #[error("Client with id `{0}` is unknown")]
+    UnknownClient(ClientId),
+    /// A channel id is invalid
+    #[error("Channel with id `{0}` is invalid")]
+    InvalidChannelId(ChannelId),
+    /// A channel is closed
+    #[error("Channel is closed")]
+    ChannelClosed,
+
+    #[error("TODO")]
+    ChannelSendError(#[from] AsyncChannelError),
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum PayloadSendError {
+    /// There is no default channel
+    #[error("There is no default channel")]
+    NoDefaultChannel,
+
+    #[error("TODO")]
+    SendError(#[from] SendError),
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum MessageSendError {
+    /// Failed serialization
+    #[error("Failed serialization")]
+    Serialization,
+    /// There is no default channel
+    #[error("There is no default channel")]
+    NoDefaultChannel,
+
+    #[error("TODO")]
+    SendError(#[from] SendError),
+}
+
+#[derive(thiserror::Error, Debug)]
+#[error("Error while sending to multiple recipients")]
+pub struct GroupSendError(pub Vec<(ClientId, SendError)>);
+
+#[derive(thiserror::Error, Debug)]
+pub enum GroupPayloadSendError {
+    /// There is no default channel
+    #[error("There is no default channel")]
+    NoDefaultChannel,
+
+    #[error("TODO")]
+    GroupSendError(#[from] GroupSendError),
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum GroupMessageSendError {
+    /// Failed serialization
+    #[error("Failed serialization")]
+    Serialization,
+    /// There is no default channel
+    #[error("There is no default channel")]
+    NoDefaultChannel,
+
+    #[error("TODO")]
+    GroupSendError(#[from] GroupSendError),
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum MessageReceiveError {
+    /// Failed deserialization
+    #[error("Failed deserialization")]
+    Deserialization,
+
+    #[error("TODO")]
+    ReceiveError(#[from] ReceiveError),
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ReceiveError {
+    /// A client id is unknown
+    #[error("Client with id `{0}` is unknown")]
+    UnknownClient(ClientId),
+    /// The receiving half of an internal channel was explicitly closed or has been dropped
+    #[error(
+        "The receiving half of the internal channel was explicitly closed or has been dropped"
+    )]
+    InternalChannelClosed,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum DisconnectError {
+    /// A client id is unknown
+    #[error("Client with id `{0}` is unknown")]
+    UnknownClient(ClientId),
+    /// A client is already disconnected
+    #[error("Client with id `{0}` is already disconnected")]
+    ClientAlreadyDisconnected(ClientId),
+}
+
+pub enum StopEndpointError {}
+
+/// Endpoint is already closed
+#[derive(thiserror::Error, Debug)]
+#[error("Endpoint is already closed")]
+pub struct EndpointAlreadyClosed;
+
+#[derive(thiserror::Error, Debug)]
+pub enum EndpointStartError {
+    /// A lock acquisition failed
+    #[error("Lock acquisition failure")]
+    LockAcquisitionFailure,
+    /// I/O Error
+    #[error("I/O error")]
+    IoError(#[from] std::io::Error),
+    /// Certificate error
+    #[error("Certificate error")]
+    CertificateError(#[from] CertificateError),
+    ///Rustls protocol error
+    #[error("Rustls protocol error")]
+    RustlsError(#[from] rustls::Error),
+
+    #[error("TODO")]
+    AsyncChannelError(#[from] AsyncChannelError),
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum CertificateError {
+    /// Failed to generate a self-signed certificate
+    #[error("Failed to generate a self-signed certificate")]
+    CertificateGenerationFailed(#[from] rcgen::Error),
+    /// I/O Error
+    #[error("I/O error")]
+    IoError(#[from] std::io::Error),
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ConnectionCloseError {
+    /// A connection is already closed
+    #[error("Connection is already closed")]
+    ConnectionAlreadyClosed,
+}

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -4,6 +4,7 @@ use bevy::{
     ecs::schedule::SystemSet,
     prelude::{Deref, DerefMut, Resource},
 };
+use channels::MAX_CHANNEL_COUNT;
 use tokio::runtime::Runtime;
 
 /// Certificate features shared by client & server
@@ -21,7 +22,13 @@ pub const DEFAULT_MESSAGE_QUEUE_SIZE: usize = 150;
 pub const DEFAULT_KEEP_ALIVE_INTERVAL_S: Duration = Duration::from_secs(4);
 
 /// Default max size for quinnet internal message channels
-pub const DEFAULT_INTERNAL_MESSAGE_CHANNEL_SIZE: usize = 100;
+pub const DEFAULT_INTERNAL_MESSAGES_CHANNEL_SIZE: usize = 100;
+
+/// Default max size for Quinnet Channels messages
+///
+/// At least MAX_CHANNEL_COUNT capacity if all available channel slots are requested to open
+pub const DEFAULT_QCHANNEL_MESSAGES_CHANNEL_SIZE: usize = 2 * MAX_CHANNEL_COUNT;
+
 /// Default max size of the queues used to transmit close messages for async tasks
 pub(crate) const DEFAULT_KILL_MESSAGE_QUEUE_SIZE: usize = 10;
 

--- a/src/shared/error.rs
+++ b/src/shared/error.rs
@@ -1,5 +1,6 @@
 use super::channels::ChannelId;
 
+/// Quinnet internal error in async<->sync communications
 #[derive(thiserror::Error, Debug)]
 pub enum AsyncChannelError {
     /// The data could not be sent on the channel because the channel is currently full and sending would require blocking
@@ -12,6 +13,7 @@ pub enum AsyncChannelError {
     InternalChannelClosed,
 }
 
+/// Error while closing a channel
 #[derive(thiserror::Error, Debug)]
 pub enum ChannelCloseError {
     /// A channel is closed
@@ -22,15 +24,18 @@ pub enum ChannelCloseError {
     InvalidChannelId(ChannelId),
 }
 
+/// Errro while creating a channel
 #[derive(thiserror::Error, Debug)]
 pub enum ChannelCreationError {
     /// The maximum number of simultaneously opened channels has been reached
     #[error("The maximum number of simultaneously opened channels has been reached")]
     MaxChannelsCountReached,
-    #[error("TODO")]
+    /// Quinnet async channel error
+    #[error("Quinnet async channel error")]
     AsyncChannelError(#[from] AsyncChannelError),
 }
 
+/// Error while configuring channels
 #[derive(thiserror::Error, Debug)]
 pub enum ChannelConfigError {
     /// The maximum number of configured channels has been reached

--- a/src/shared/error.rs
+++ b/src/shared/error.rs
@@ -1,54 +1,7 @@
-use std::{io, net::AddrParseError, sync::PoisonError};
+use super::channels::ChannelId;
 
-use crate::client::connection::ConnectionLocalId;
-
-use super::{channels::ChannelId, ClientId};
-
-/// Enum with possibles errors that can occur in Bevy Quinnet
 #[derive(thiserror::Error, Debug)]
-pub enum QuinnetError {
-    /// IP/Socket address is invalid
-    #[error("IP/Socket address is invalid")]
-    InvalidAddress(#[from] AddrParseError),
-    /// Failed to generate a self-signed certificate
-    #[error("Failed to generate a self-signed certificate")]
-    CertificateGenerationFailed(#[from] rcgen::Error),
-    /// A client id is unknown
-    #[error("Client with id `{0}` is unknown")]
-    UnknownClient(ClientId),
-    /// A client is already disconnected
-    #[error("Client with id `{0}` is already disconnected")]
-    ClientAlreadyDisconnected(ClientId),
-    /// A connection id is unknown
-    #[error("Connection with id `{0}` is unknown")]
-    UnknownConnection(ConnectionLocalId),
-    /// A connection is closed
-    #[error("Connection is 'disconnected'")]
-    ConnectionClosed,
-    /// A connection is already closed
-    #[error("Connection is already closed")]
-    ConnectionAlreadyClosed,
-    /// A channel is unknown
-    #[error("Channel with id `{0}` is unknown")]
-    UnknownChannel(ChannelId),
-    /// A channel is already closed
-    #[error("Channel is already closed")]
-    ChannelClosed,
-    /// A connection has no default channel
-    #[error("The connection has no default channel")]
-    NoDefaultChannel,
-    /// The maximum number of simultaneously opened channels has been reached
-    #[error("The maximum number of simultaneously opened channels has been reached")]
-    MaxChannelsCountReached,
-    /// Endpoint is already closed
-    #[error("Endpoint is already closed")]
-    EndpointAlreadyClosed,
-    /// Failed serialization
-    #[error("Failed serialization")]
-    Serialization,
-    /// Failed deserialization
-    #[error("Failed deserialization")]
-    Deserialization,
+pub enum AsyncChannelError {
     /// The data could not be sent on the channel because the channel is currently full and sending would require blocking
     #[error("The data could not be sent on the channel because the channel is currently full and sending would require blocking")]
     FullQueue,
@@ -57,25 +10,30 @@ pub enum QuinnetError {
         "The receiving half of the internal channel was explicitly closed or has been dropped"
     )]
     InternalChannelClosed,
-    /// An host file is invalid
-    #[error("The hosts file is invalid")]
-    InvalidHostFile,
-    /// A lock acquisition failed
-    #[error("Lock acquisition failure")]
-    LockAcquisitionFailure,
-    /// A Certificate action was already sent for a CertificateInteractionEvent
-    #[error("A Certificate action was already sent for a CertificateInteractionEvent")]
-    CertificateActionAlreadyApplied,
-    /// I/O Error
-    #[error("I/O error")]
-    IoError(#[from] io::Error),
-    ///Rustls protocol error
-    #[error("Rustls protocol error")]
-    RustlsError(#[from] rustls::Error),
 }
 
-impl<T> From<PoisonError<T>> for QuinnetError {
-    fn from(_: PoisonError<T>) -> Self {
-        Self::LockAcquisitionFailure
-    }
+#[derive(thiserror::Error, Debug)]
+pub enum ChannelCloseError {
+    /// A channel is closed
+    #[error("Channel is closed already")]
+    ChannelAlreadyClosed,
+    /// A channel id is invalid
+    #[error("Channel with id `{0}` is invalid")]
+    InvalidChannelId(ChannelId),
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ChannelCreationError {
+    /// The maximum number of simultaneously opened channels has been reached
+    #[error("The maximum number of simultaneously opened channels has been reached")]
+    MaxChannelsCountReached,
+    #[error("TODO")]
+    AsyncChannelError(#[from] AsyncChannelError),
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ChannelConfigError {
+    /// The maximum number of configured channels has been reached
+    #[error("The maximum number of configured channels has been reached")]
+    MaxChannelsCountReached,
 }

--- a/tests/certificates.rs
+++ b/tests/certificates.rs
@@ -149,9 +149,7 @@ fn trust_on_first_use() {
 
         // Clients disconnects
         // Client reconnects with the updated cert store
-        client
-            .close_all_connections()
-            .expect("Failed to close connections on the client");
+        client.close_all_connections();
 
         client
             .open_connection(
@@ -185,8 +183,7 @@ fn trust_on_first_use() {
         client_app
             .world_mut()
             .resource_mut::<QuinnetClient>()
-            .close_all_connections()
-            .expect("Failed to close connections on the client");
+            .close_all_connections();
     }
 
     // Server reboots, and generates a new self-signed certificate

--- a/tests/channels.rs
+++ b/tests/channels.rs
@@ -2,7 +2,7 @@ use bevy::prelude::App;
 
 use bevy_quinnet::{
     client::QuinnetClient,
-    server::{GroupMessageSendError, QuinnetServer},
+    server::{QuinnetServer, ServerGroupMessageSendError},
     shared::channels::{ChannelKind, DEFAULT_MAX_RELIABLE_FRAME_LEN},
 };
 
@@ -46,7 +46,7 @@ fn default_channel() {
                 server
                     .endpoint_mut()
                     .broadcast_message(SharedMessage::TestMessage("".to_string())),
-                Err(GroupMessageSendError::NoDefaultChannel)
+                Err(ServerGroupMessageSendError::NoDefaultChannel)
             ),
             "Should not be able to send on default channel"
         );
@@ -64,7 +64,7 @@ fn default_channel() {
                 client
                     .connection_mut()
                     .send_message(SharedMessage::TestMessage("".to_string())),
-                Err(bevy_quinnet::client::MessageSendError::NoDefaultChannel)
+                Err(bevy_quinnet::client::ClientMessageSendError::NoDefaultChannel)
             ),
             "Should not be able to send on default channel"
         );

--- a/tests/channels.rs
+++ b/tests/channels.rs
@@ -2,11 +2,8 @@ use bevy::prelude::App;
 
 use bevy_quinnet::{
     client::QuinnetClient,
-    server::QuinnetServer,
-    shared::{
-        channels::{ChannelKind, DEFAULT_MAX_RELIABLE_FRAME_LEN},
-        error::QuinnetError,
-    },
+    server::{GroupMessageSendError, QuinnetServer},
+    shared::channels::{ChannelKind, DEFAULT_MAX_RELIABLE_FRAME_LEN},
 };
 
 // https://github.com/rust-lang/rust/issues/46379
@@ -49,7 +46,7 @@ fn default_channel() {
                 server
                     .endpoint_mut()
                     .broadcast_message(SharedMessage::TestMessage("".to_string())),
-                Err(QuinnetError::NoDefaultChannel)
+                Err(GroupMessageSendError::NoDefaultChannel)
             ),
             "Should not be able to send on default channel"
         );
@@ -67,7 +64,7 @@ fn default_channel() {
                 client
                     .connection_mut()
                     .send_message(SharedMessage::TestMessage("".to_string())),
-                Err(QuinnetError::NoDefaultChannel)
+                Err(bevy_quinnet::client::MessageSendError::NoDefaultChannel)
             ),
             "Should not be able to send on default channel"
         );


### PR DESCRIPTION
- Fixes #38, 
  - Collections errors (group_message, broadcast, ...) are now properly accumulated
  - Opening new dynamic channels on an endpoint gracefully fails if any connection fails to open a channel
- Splits the monolithic `QuinnetError` enum into multiple error types

Todos:
- [x] Test
- [ ] Update changelog
- [x] Update documentation
